### PR TITLE
🌍 #6 Implement void properties with no configuration

### DIFF
--- a/src/GalaxyCheck.Xunit/Internal/PropertyTestCase.cs
+++ b/src/GalaxyCheck.Xunit/Internal/PropertyTestCase.cs
@@ -1,5 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -21,6 +28,81 @@ namespace GalaxyCheck.Xunit.Internal
             object[]? testMethodArguments = null)
             : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
         {
+        }
+
+        public override Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            object[] constructorArguments,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+        {
+            messageBus.QueueMessage(new TestCaseStarting(this));
+
+            var summary = new RunSummary();
+
+            var test = new XunitTest(this, DisplayName);
+
+            foreach (var constructorArgument in constructorArguments)
+            {
+                if (constructorArgument is TestOutputHelper testOutputHelper)
+                {
+                    testOutputHelper.Initialize(messageBus, test);
+                }
+            }
+
+            var methodInfo = TestMethod.Method.ToRuntimeMethod();
+            if (methodInfo.ReturnType != typeof(void))
+            {
+                aggregator.Add(new NotImplementedException("Non-void properties are not yet implemented"));
+                return Task.FromResult(summary);
+            }
+
+            IMessageSinkMessage resultMessage = RunProperty(TestMethod.TestClass.Class.ToRuntimeType(), methodInfo, constructorArguments) switch
+            {
+                Exception ex => new TestFailed(test, 0, "", ex),
+                null => new TestPassed(test, 0, ""),
+            };
+
+            messageBus.QueueMessage(resultMessage);
+
+            return Task.FromResult(summary);
+        }
+
+        private static Exception? RunProperty(
+            Type testClass,
+            MethodInfo testMethod,
+            object[] constructorArguments)
+        {
+            var testInstance = Activator.CreateInstance(testClass, constructorArguments);
+            try
+            {
+                testMethod.Assert(
+                    testInstance,
+                    formatValue: x => x.Length switch
+                    {
+                        0 => "(no value)",
+                        1 => JsonSerializer.Serialize(x[0]),
+                        _ => JsonSerializer.Serialize(x)
+                    },
+                    formatReproduction: (x) =>
+                    {
+                        var attributes =
+                            new List<(string name, string value)>
+                            {
+                                ("Seed", x.seed.ToString(CultureInfo.InvariantCulture)),
+                                ("Size", x.size.ToString(CultureInfo.InvariantCulture)),
+                            }
+                            .Select(x => $"{x.name} = {x.value}");
+
+                        return $"({ string.Join(", ", attributes) })";
+                    });
+                return null;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
         }
     }
 }

--- a/src/GalaxyCheck/Runners/Assert.cs
+++ b/src/GalaxyCheck/Runners/Assert.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 
 namespace GalaxyCheck
 {
@@ -12,12 +13,18 @@ namespace GalaxyCheck
             this IProperty<T> property,
             int? iterations = null,
             int? seed = null,
-            int? size = null)
+            int? size = null,
+            Func<object?, string>? formatValue = null,
+            Func<(int seed, int size, IEnumerable<int> path), string>? formatReproduction = null)
         {
             var checkResult = property.Check(iterations: iterations, seed: seed, size: size);
             if (checkResult.Falsified)
             {
-                throw new PropertyFailedException(BoxCounterexample(checkResult.Counterexample!), checkResult.Iterations);
+                throw new PropertyFailedException(
+                    BoxCounterexample(checkResult.Counterexample!),
+                    checkResult.Iterations,
+                    formatValue,
+                    formatReproduction);
             }
         }
 
@@ -33,30 +40,75 @@ namespace GalaxyCheck
                 counterexample.RepeatPath,
                 counterexample.Exception);
         }
+
+        public static void Assert(
+            this MethodInfo methodInfo,
+            object? target = null,
+            int? iterations = null,
+            int? seed = null,
+            int? size = null,
+            Func<object[], string>? formatValue = null,
+            Func<(int seed, int size, IEnumerable<int> path), string>? formatReproduction = null)
+        {
+            var gen = Parameters(methodInfo);
+
+            var property = gen.ForAll(parameters =>
+            {
+                try
+                {
+                    methodInfo.Invoke(target, parameters);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    throw ex.InnerException;
+                }
+            });
+
+            Assert(
+                property,
+                iterations: iterations,
+                seed: seed,
+                size: size,
+                formatValue: formatValue == null ? null : x => formatValue((object[])x),
+                formatReproduction: formatReproduction);
+        }
     }
+
 }
 
 namespace GalaxyCheck.Runners
 {
     public class PropertyFailedException : Exception
     {
-        public PropertyFailedException(Counterexample<object?> counterexample, int iterations)
-            : base(BuildMessage(counterexample, iterations))
+        public PropertyFailedException(
+            Counterexample<object?> counterexample,
+            int iterations,
+            Func<object?, string>? formatValue,
+            Func<(int seed, int size, IEnumerable<int> path), string>? formatReproduction)
+            : base(BuildMessage(counterexample, iterations, formatValue, formatReproduction))
         {
         }
 
-        private static string BuildMessage(Counterexample<object?> counterexample, int iterations) =>
-            string.Join(Environment.NewLine, BuildLines(counterexample, iterations));
+        private static string BuildMessage(
+            Counterexample<object?> counterexample,
+            int iterations,
+            Func<object?, string>? formatValue,
+            Func<(int seed, int size, IEnumerable<int> path), string>? formatReproduction) =>
+                string.Join(Environment.NewLine, BuildLines(counterexample, iterations, formatValue, formatReproduction));
 
-        private static IEnumerable<string> BuildLines(Counterexample<object?> counterexample, int iterations)
+        private static IEnumerable<string> BuildLines(
+            Counterexample<object?> counterexample,
+            int iterations,
+            Func<object?, string>? formatValue,
+            Func<(int seed, int size, IEnumerable<int> path), string>? formatReproduction)
         {
             const string LineBreak = "";
 
             yield return LineBreak;
 
             yield return FalsifiedAfterLine(iterations);
-            yield return ReproductionLine(counterexample);
-            yield return CounterexampleValueLine(counterexample);
+            yield return ReproductionLine(counterexample, formatReproduction);
+            yield return CounterexampleValueLine(counterexample, formatValue);
 
             yield return LineBreak;
             if (counterexample.Exception == null)
@@ -71,24 +123,38 @@ namespace GalaxyCheck.Runners
 
         private static string FalsifiedAfterLine(int iterations) => iterations == 1 ? "Falsified after 1 test" : $"Falsified after {iterations} tests";
 
-        private static string ReproductionLine(Counterexample<object?> counterexample)
+        private static string ReproductionLine(
+            Counterexample<object?> counterexample,
+            Func<(int seed, int size, IEnumerable<int> path), string>? formatReproduction)
         {
-            var pathFormatted = "new [] { }";
+            static string PrefixLine(string reproductionFormatted) => $"Reproduction: {reproductionFormatted}";
 
-            var attributes =
-                new List<(string name, string value)>
-                {
-                    ("Seed", counterexample.RepeatRng.Seed.ToString(CultureInfo.InvariantCulture)),
-                    ("Size", counterexample.RepeatSize.Value.ToString(CultureInfo.InvariantCulture)),
-                    ("Path", pathFormatted)
-                }
-                .Select(x => $"{x.name} = {x.value}");
+            if (formatReproduction == null)
+            {
+                var attributes =
+                    new List<(string name, string value)>
+                    {
+                        ("Seed", counterexample.RepeatRng.Seed.ToString(CultureInfo.InvariantCulture)),
+                        ("Size", counterexample.RepeatSize.Value.ToString(CultureInfo.InvariantCulture)),
+                    }
+                    .Select(x => $"{x.name} = {x.value}");
 
-            return $"Reproduction: ({string.Join(", ", attributes)})";
+                return PrefixLine($"({string.Join(", ", attributes)})");
+            }
+            else
+            {
+                var reproduction = (counterexample.RepeatRng.Seed, counterexample.RepeatSize.Value, counterexample.RepeatPath);
+                return PrefixLine(formatReproduction(reproduction));
+            }
         }
 
-        private static string CounterexampleValueLine(Counterexample<object?> counterexample) =>
-            $"Counterexample: {counterexample.Value}";
+        private static string CounterexampleValueLine(
+            Counterexample<object?> counterexample,
+            Func<object?, string>? formatValue)
+        {
+            var formattedValue = formatValue?.Invoke(counterexample.Value) ?? counterexample.Value?.ToString(); 
+            return $"Counterexample: {formattedValue}";
+        }
 
         private static string ExceptionLine(Exception ex) => $"---- {ex.Message}";
     }


### PR DESCRIPTION
Most of the invocation logic layed out in #8 can probably be implemented as part of the core framework.

That way it will be able to be utilized by future integrations.

For example, the idea of a property test case being able to return void, bool, or another property. Also preconditions.