### PR TITLE
🌍 #11 Basic implementation of converting a MethodInfo to a property

### DIFF
--- a/src/GalaxyCheck/Property.cs
+++ b/src/GalaxyCheck/Property.cs
@@ -1,0 +1,51 @@
+﻿using System.Reflection;
+
+namespace GalaxyCheck
+{
+    public static class Property
+    {
+        public static IProperty<object[]> ToProperty(this MethodInfo methodInfo, object? target)
+        {
+            return methodInfo.ReturnType == typeof(void)
+                ? ToVoidProperty(methodInfo, target)
+                : methodInfo.ReturnType == typeof(bool)
+                ? ToBooleanProperty(methodInfo, target)
+                : ThrowUnhandled<IProperty<object[]>>("Unhandled return type");
+        }
+
+        private static IProperty<object[]> ToVoidProperty(MethodInfo methodInfo, object? target)
+        {
+            return Gen.Parameters(methodInfo).ForAll(parameters =>
+            {
+                try
+                {
+                    methodInfo.Invoke(target, parameters);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    throw ex.InnerException;
+                }
+            });
+        }
+
+        private static IProperty<object[]> ToBooleanProperty(MethodInfo methodInfo, object? target)
+        {
+            return Gen.Parameters(methodInfo).ForAll(parameters =>
+            {
+                try
+                {
+                    return (bool)methodInfo.Invoke(target, parameters);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    throw ex.InnerException;
+                }
+            });
+        }
+
+        private static T ThrowUnhandled<T>(string message)
+        {
+            throw new System.Exception(message);
+        }
+    }
+}

--- a/tests/GalaxyCheck.Tests.V2/GalaxyCheck.Tests.V2.csproj
+++ b/tests/GalaxyCheck.Tests.V2/GalaxyCheck.Tests.V2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>

--- a/tests/GalaxyCheck.Tests.V2/GenAssert.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenAssert.cs
@@ -1,0 +1,45 @@
+﻿using GalaxyCheck;
+using GalaxyCheck.Internal.ExampleSpaces;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Tests.V2
+{
+    public static class GenAssert
+    {
+        public static void Equal<T>(IGen<T> expected, IGen<T> actual, int seed, int? iterations = null)
+        {
+            var expectedSample = expected.Select(x => JsonConvert.SerializeObject(x)).Advanced.SampleExampleSpaces(seed: seed, iterations: iterations);
+            var actualSample = actual.Select(x => JsonConvert.SerializeObject(x)).Advanced.SampleExampleSpaces(seed: seed, iterations: iterations);
+
+            Assert.All(
+                Enumerable.Zip(expectedSample, actualSample),
+                (x) =>
+                {
+                    Assert.Equal(x.First.Sample(), x.Second.Sample());
+                });
+        }
+
+        public static List<Example<T>> Sample<T>(
+            this ExampleSpace<T> exampleSpace,
+            int maxExamples = 10)
+        {
+            static IEnumerable<Example<T>> SampleRec(ExampleSpace<T> exampleSpace)
+            {
+                yield return exampleSpace.Current;
+
+                foreach (var subExampleSpace in exampleSpace.Subspace.SelectMany(es => SampleRec(es)))
+                {
+                    yield return subExampleSpace;
+                }
+            }
+
+            return SampleRec(exampleSpace).Take(maxExamples).ToList();
+        }
+    }
+}

--- a/tests/GalaxyCheck.Tests.V2/PropertyTests/AboutMethodInfoProperties/AboutMethodInfoInput.cs
+++ b/tests/GalaxyCheck.Tests.V2/PropertyTests/AboutMethodInfoProperties/AboutMethodInfoInput.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using Xunit;
+
+using GalaxyCheck;
+using DevGen = GalaxyCheck.Gen;
+
+namespace Tests.V2.PropertyTests.AboutMethodInfoProperties
+{
+    /// <summary>
+    /// TODO:
+    ///     - Use different gen types as parameters when supported as parameters. Otherwise we are vulnerable to parameter
+    ///       ordering bugs.
+    /// </summary>
+    public class AboutMethodInfoInput
+    {
+        [Fact]
+        public void AVoidMethodInfoReceivesInputLikeForAll()
+        {
+            var gen0 = DevGen.Int32();
+            var gen1 = DevGen.Int32();
+
+            var forAllProperty = DevGen.ForAll(gen0, gen1, (x, y) => { });
+            var forAllPropertyInput = forAllProperty.Select(x => new object[] { x.Input.Item1, x.Input.Item2 });
+
+            Action<int, int> f = (x, y) => { };
+            var methodInfoProperty = f.Method.ToProperty(null);
+            var methodInfoPropertyInput = methodInfoProperty.Select(x => x.Input);
+
+            GenAssert.Equal(forAllPropertyInput, methodInfoPropertyInput, 0, 10);
+        }
+
+        [Fact]
+        public void ABooleanReturningMethodInfoReceivesInputLikeForAll()
+        {
+            var gen0 = DevGen.Int32();
+            var gen1 = DevGen.Int32();
+
+            var forAllProperty = DevGen.ForAll(gen0, gen1, (x, y) => true);
+            var forAllPropertyInput = forAllProperty.Select(x => new object[] { x.Input.Item1, x.Input.Item2 });
+
+            Func<int, int, bool> f = (x, y) => true;
+            var methodInfoProperty = f.Method.ToProperty(null);
+            var methodInfoPropertyInput = methodInfoProperty.Select(x => x.Input);
+
+            GenAssert.Equal(forAllPropertyInput, methodInfoPropertyInput, 0, 10);
+        }
+
+        [Fact(Skip = "TODO")]
+        public void APropertyReturningMethodInfoReceivesAConcatenationOfInput()
+        {
+            var gen0 = DevGen.Int32();
+            var gen1 = DevGen.Int32();
+
+            var forAllProperty = DevGen.ForAll(gen0, gen1, (x, y) => true);
+            var forAllPropertyInput = forAllProperty.Select(x => new object[] { x.Input.Item1, x.Input.Item2 });
+
+            Func<int, IProperty<int>> f = (x) => gen1.ForAll(y => true);
+            var methodInfoProperty = f.Method.ToProperty(null);
+            var methodInfoPropertyInput = methodInfoProperty.Select(x => x.Input);
+
+            GenAssert.Equal(forAllPropertyInput, methodInfoPropertyInput, 0, 10);
+        }
+    }
+}

--- a/tests/GalaxyCheck.Tests.V2/PropertyTests/AboutMethodInfoProperties/AboutMethodInfoOutput.cs
+++ b/tests/GalaxyCheck.Tests.V2/PropertyTests/AboutMethodInfoProperties/AboutMethodInfoOutput.cs
@@ -1,0 +1,75 @@
+﻿using FluentAssertions;
+using System;
+using System.Reflection;
+using Xunit;
+
+using GalaxyCheck;
+
+namespace Tests.V2.PropertyTests.AboutMethodInfoProperties
+{
+    public class AboutMethodInfoOutput
+    {
+        private void AnInfallibleVoidPropertyFunction() { }
+
+        [Fact]
+        public void AVoidMethodInfoCanBeUnfalsifiable()
+        {
+            var property = GetMethod(nameof(AnInfallibleVoidPropertyFunction)).ToProperty(this);
+
+            var checkResult = property.Check();
+
+            checkResult.Falsified.Should().BeFalse();
+        }
+
+        private void AFallibleVoidPropertyFunction(int x)
+        {
+            Assert.True(x < 100);
+        }
+
+        [Fact]
+        public void AVoidMethodInfoCanBeFalsified()
+        {
+            var property = GetMethod(nameof(AFallibleVoidPropertyFunction)).ToProperty(this);
+
+            var checkResult = property.Check();
+
+            checkResult.Falsified.Should().BeTrue();
+        }
+
+        private bool AnInfallibleBooleanPropertyFunction() => true;
+
+        [Fact]
+        public void ABooleanMethodInfoCanBeUnfalsifiable()
+        {
+            var property = GetMethod(nameof(AnInfallibleBooleanPropertyFunction)).ToProperty(this);
+
+            var checkResult = property.Check();
+
+            checkResult.Falsified.Should().BeFalse();
+        }
+
+        private bool AFallibleBooleanPropertyFunction(int x) => x < 100;
+
+        [Fact]
+        public void ABooleanMethodInfoCanBeFalsified()
+        {
+            var property = GetMethod(nameof(AFallibleBooleanPropertyFunction)).ToProperty(this);
+
+            var checkResult = property.Check();
+
+            checkResult.Falsified.Should().BeTrue();
+        }
+
+        private static MethodInfo GetMethod(string name)
+        {
+            var methodInfo = typeof(AboutMethodInfoOutput).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (methodInfo == null)
+            {
+                throw new Exception("Unable to locate method");
+            }
+
+            return methodInfo;
+        }
+    }
+}


### PR DESCRIPTION
Taking a reflected method we can convert it to a property and check it, using generators as input and then evaluating the output.

Only adds supports for syncrhonous void and boolean properties.