### PR TITLE
🌍 #84 Limit the number of shrinks during a failure to the given limit

### DIFF
--- a/src/GalaxyCheck.Xunit/Internal/PropertyTestCase.cs
+++ b/src/GalaxyCheck.Xunit/Internal/PropertyTestCase.cs
@@ -75,11 +75,12 @@ namespace GalaxyCheck.Xunit.Internal
                 return Fail(exception);
             }
 
+            var propertyAttribute = methodInfo.GetCustomAttributes<PropertyAttribute>().Single();
             var replay = methodInfo.GetCustomAttributes<ReplayAttribute>().SingleOrDefault()?.Replay;
 
             try
             {
-                RunProperty(property, replay, testOutputHelper);
+                RunProperty(property, propertyAttribute.ShrinkLimit, replay, testOutputHelper);
                 return Pass();
             }
             catch (Exception propertyFailedException)
@@ -88,10 +89,11 @@ namespace GalaxyCheck.Xunit.Internal
             }
         }
 
-        protected virtual void RunProperty(Property<object> property, string? replay, ITestOutputHelper testOutputHelper)
+        protected virtual void RunProperty(Property<object> property, int shrinkLimit, string? replay, ITestOutputHelper testOutputHelper)
         {
             property.Assert(
                 replay: replay,
+                shrinkLimit: shrinkLimit,
                 formatReproduction: (newReplay) => $"{Environment.NewLine}    [Replay(\"{newReplay}\")]",
                 formatMessage: (x) => Environment.NewLine + Environment.NewLine + x);
         }

--- a/src/GalaxyCheck.Xunit/Internal/SampleTestCase.cs
+++ b/src/GalaxyCheck.Xunit/Internal/SampleTestCase.cs
@@ -24,7 +24,7 @@ namespace GalaxyCheck.Xunit.Internal
         {
         }
 
-        protected override void RunProperty(Property<object> property, string? replay, ITestOutputHelper testOutputHelper)
+        protected override void RunProperty(Property<object> property, int shrinkLimit, string? replay, ITestOutputHelper testOutputHelper)
         {
             var log = new List<string>();
 

--- a/src/GalaxyCheck.Xunit/PropertyAttribute.cs
+++ b/src/GalaxyCheck.Xunit/PropertyAttribute.cs
@@ -8,5 +8,6 @@ namespace GalaxyCheck.Xunit
     [XunitTestCaseDiscoverer("GalaxyCheck.Xunit.Internal.PropertyDiscoverer", "GalaxyCheck.Xunit")]
     public class PropertyAttribute : FactAttribute
     {
+        public int ShrinkLimit { get; set; } = 500;
     }
 }

--- a/src/GalaxyCheck/Gen.cs
+++ b/src/GalaxyCheck/Gen.cs
@@ -3,6 +3,7 @@ using GalaxyCheck.Injection;
 using GalaxyCheck.Internal.ExampleSpaces;
 using GalaxyCheck.Internal.Gens;
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace GalaxyCheck
@@ -31,9 +32,7 @@ namespace GalaxyCheck
         /// <typeparam name="T">The type of the generator's value.</typeparam>
         /// <param name="value">The constant value the generator should produce.</param>
         /// <returns>The new generator.</returns>
-        public static IGen<T> Constant<T>(T value) => Advanced.Create(
-            (useNextInt, size) => value,
-            identify: IdentifyFuncs.Constant<T>());
+        public static IGen<T> Constant<T>(T value) => Advanced.Create((useNextInt, size) => value);
 
         /// <summary>
         /// Creates a generator that produces parameters to the given method. Can be used to dynamically invoke a
@@ -45,21 +44,7 @@ namespace GalaxyCheck
 
         public static partial class Advanced
         {
-            public static IGen<T> Create<T>(
-                StatefulGenFunc<T> generate,
-                ShrinkFunc<T>? shrink = null,
-                MeasureFunc<T>? measure = null,
-                IdentifyFunc<T>? identify = null) => Create(
-                    generate,
-                    value => ExampleSpaceFactory.Unfold(
-                        value,
-                        shrink ?? ShrinkFunc.None<T>(),
-                        measure ?? MeasureFunc.Unmeasured<T>(),
-                        identify ?? IdentifyFuncs.Default<T>()));
-
-            public static IGen<T> Create<T>(
-                StatefulGenFunc<T> generate,
-                Func<T, IExampleSpace<T>> unfold) => new PrimitiveGen<T>(generate, unfold);
+            public static IGen<T> Create<T>(StatefulGenFunc<T> generate) => new PrimitiveGen<T>(generate);
         }
     }
 }

--- a/src/GalaxyCheck/Gens/Int32Gen.cs
+++ b/src/GalaxyCheck/Gens/Int32Gen.cs
@@ -149,9 +149,9 @@ namespace GalaxyCheck.Gens.Int32
                 ? CreateBiasedStatefulGen(min, max, origin)
                 : CreateUnbiasedStatefulGen(min, max);
 
-            return Gen.Advanced.Create(
-                statefulGen,
-                value => ExampleSpaceFactory.Int32(value: value, origin: origin, min: min, max: max));
+            return Gen
+                .Advanced.Create(statefulGen)
+                .Advanced.Unfold(value => ExampleSpaceFactory.Int32(value: value, origin: origin, min: min, max: max));
         }
 
         private static StatefulGenFunc<int> CreateUnbiasedStatefulGen(int min, int max) =>

--- a/src/GalaxyCheck/Internal/ExampleSpaces/ExampleSpaceFactory.cs
+++ b/src/GalaxyCheck/Internal/ExampleSpaces/ExampleSpaceFactory.cs
@@ -47,6 +47,7 @@ namespace GalaxyCheck.Internal.ExampleSpaces
         /// <param name="rootValue"></param>
         /// <param name="shrink"></param>
         /// <param name="measure"></param>
+        /// <param name="identify"></param>
         /// <returns></returns>
         public static IExampleSpace<T> Unfold<T>(
             T rootValue,

--- a/src/GalaxyCheck/Internal/ExampleSpaces/ExplorationStage.cs
+++ b/src/GalaxyCheck/Internal/ExampleSpaces/ExplorationStage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GalaxyCheck.Internal.ExampleSpaces
 {
@@ -67,5 +68,17 @@ namespace GalaxyCheck.Internal.ExampleSpaces
                 onCounterexampleExploration: (_) => true,
                 onNonCounterexampleExploration: (_) => false,
                 onDiscardExploration: () => false);
+
+        public static ExplorationStage<T> PrependPath<T>(
+            this ExplorationStage<T> explorationStage,
+            IEnumerable<int> path) => explorationStage.Match(
+                onNonCounterexampleExploration: nonCounterexample => ExplorationStage<T>.Factory.NonCounterexample(
+                    nonCounterexample.ExampleSpace,
+                    Enumerable.Concat(path, nonCounterexample.Path)),
+                onCounterexampleExploration: counterexample => ExplorationStage<T>.Factory.Counterexample(
+                    counterexample.ExampleSpace,
+                    Enumerable.Concat(path, counterexample.Path),
+                    counterexample.Exception),
+                onDiscardExploration: () => ExplorationStage<T>.Factory.Discard());
     }
 }

--- a/src/GalaxyCheck/Internal/Gens/PrimitiveGen.cs
+++ b/src/GalaxyCheck/Internal/Gens/PrimitiveGen.cs
@@ -1,7 +1,6 @@
 ﻿using GalaxyCheck.Internal.ExampleSpaces;
 using GalaxyCheck.Internal.GenIterations;
 using GalaxyCheck.Internal.Sizing;
-using System;
 using System.Collections.Generic;
 
 namespace GalaxyCheck.Internal.Gens
@@ -13,14 +12,10 @@ namespace GalaxyCheck.Internal.Gens
     public class PrimitiveGen<T> : BaseGen<T>, IGen<T>
     {
         private readonly StatefulGenFunc<T> _generate;
-        private readonly Func<T, IExampleSpace<T>> _unfold;
 
-        public PrimitiveGen(
-            StatefulGenFunc<T> generate,
-            Func<T, IExampleSpace<T>> unfold)
+        public PrimitiveGen(StatefulGenFunc<T> generate)
         {
             _generate = generate;
-            _unfold = unfold;
         }
 
         protected override IEnumerable<IGenIteration<T>> Run(GenParameters parameters)
@@ -36,7 +31,7 @@ namespace GalaxyCheck.Internal.Gens
             {
                 var initialParameters = parameters;
 
-                var exampleSpace = _unfold(_generate(useNextInt, parameters.Size));
+                var exampleSpace = ExampleSpaceFactory.Singleton(_generate(useNextInt, parameters.Size));
 
                 yield return GenIterationFactory.Instance(initialParameters, parameters, exampleSpace);
             } while (true);

--- a/src/GalaxyCheck/Operators/AsGen.cs
+++ b/src/GalaxyCheck/Operators/AsGen.cs
@@ -1,0 +1,19 @@
+﻿namespace GalaxyCheck
+{
+    public static partial class Extensions
+    {
+        public static IGen<T> AsGen<T>(this IGenAdvanced<T> advanced) => new AdvancedToGen<T>(advanced);
+
+        private class AdvancedToGen<T> : IGen<T>
+        {
+            public AdvancedToGen(IGenAdvanced<T> advanced)
+            {
+                Advanced = advanced;
+            }
+
+            public IGenAdvanced<T> Advanced { get; }
+
+            IGenAdvanced IGen.Advanced => Advanced;
+        }
+    }
+}

--- a/src/GalaxyCheck/Operators/Unfold.cs
+++ b/src/GalaxyCheck/Operators/Unfold.cs
@@ -1,0 +1,42 @@
+﻿using GalaxyCheck.Internal.ExampleSpaces;
+using GalaxyCheck.Internal.GenIterations;
+using GalaxyCheck.Internal.Gens;
+using System;
+using System.Collections.Generic;
+
+namespace GalaxyCheck
+{
+    public static partial class Extensions
+    {
+        public static IGen<T> Unfold<T>(
+            this IGenAdvanced<T> advanced,
+            Func<T, IEnumerable<T>> shrinkValue,
+            Func<T, decimal>? measureValue = null,
+            Func<T, int>? identifyValue = null)
+        {
+            return advanced.Unfold(value => ExampleSpaceFactory.Unfold(
+                value,
+                shrinkValue.Invoke,
+                measureValue == null ? MeasureFunc.Unmeasured<T>() : measureValue.Invoke,
+                identifyValue == null ? IdentifyFuncs.Default<T>() : value0 => ExampleId.Primitive(identifyValue(value0))));
+        }
+
+        public static IGen<T> Unfold<T>(
+            this IGenAdvanced<T> advanced,
+            Func<T, IExampleSpace<T>> unfolder)
+        {
+            GenInstanceTransformation<T, T> transformation = (instance) =>
+            {
+                return GenIterationFactory.Instance(
+                    instance.RepeatParameters,
+                    instance.NextParameters,
+                    unfolder(instance.ExampleSpace.Current.Value),
+                    instance.ExampleSpaceHistory);
+            };
+
+            return advanced
+                .AsGen()
+                .TransformInstances(transformation);
+        }
+    }
+}

--- a/src/GalaxyCheck/Runners/Assert.cs
+++ b/src/GalaxyCheck/Runners/Assert.cs
@@ -14,11 +14,12 @@ namespace GalaxyCheck
             int? iterations = null,
             int? seed = null,
             int? size = null,
+            int? shrinkLimit = null,
             string? replay = null,
             Func<string, string>? formatReproduction = null,
             Func<string, string>? formatMessage = null)
         {
-            var checkResult = property.Check(iterations: iterations, seed: seed, size: size, replay: replay);
+            var checkResult = property.Check(iterations: iterations, seed: seed, size: size, shrinkLimit: shrinkLimit, replay: replay);
 
             if (checkResult.Falsified)
             {

--- a/src/GalaxyCheck/Runners/Check.cs
+++ b/src/GalaxyCheck/Runners/Check.cs
@@ -85,6 +85,7 @@ namespace GalaxyCheck
              int? iterations = null,
              int? seed = null,
              int? size = null,
+             int? shrinkLimit = null,
              string? replay = null)
         {
             var initialParameters = new GenParameters(
@@ -93,7 +94,13 @@ namespace GalaxyCheck
 
             ResizeStrategy<T> resizeStrategy = size == null ? SuperStrategicResize<T> : NoopResize<T>;
 
-            var initialState = CheckState<T>.Create(property, iterations ?? 100, initialParameters, resizeStrategy);
+            var initialState = CheckState<T>.Create(
+                property,
+                iterations ?? 100,
+                shrinkLimit ?? 500,
+                initialParameters,
+                resizeStrategy);
+
             AbstractTransition<T> initialTransition = replay == null
                 ? new InitialTransition<T>(initialState)
                 : new ReplayTransition<T>(initialState, replay);

--- a/src/GalaxyCheck/Runners/CheckAutomata/CheckState.cs
+++ b/src/GalaxyCheck/Runners/CheckAutomata/CheckState.cs
@@ -7,6 +7,7 @@ namespace GalaxyCheck.Runners.CheckAutomata
     public record CheckState<T>(
         Property<T> Property,
         int RequestedIterations,
+        int ShrinkLimit,
         int CompletedIterations,
         int Discards,
         int Shrinks,
@@ -17,11 +18,13 @@ namespace GalaxyCheck.Runners.CheckAutomata
         internal static CheckState<T> Create(
             Property<T> property,
             int requestedIterations,
+            int shrinkLimit,
             GenParameters initialParameters,
             ResizeStrategy<T> resizeStrategy) =>
                 new CheckState<T>(
                     property,
                     requestedIterations,
+                    shrinkLimit,
                     0,
                     0,
                     0,
@@ -37,6 +40,7 @@ namespace GalaxyCheck.Runners.CheckAutomata
         internal CheckState<T> IncrementCompletedIterations() => new CheckState<T>(
             Property,
             RequestedIterations,
+            ShrinkLimit,
             CompletedIterations + 1,
             Discards,
             Shrinks,
@@ -47,6 +51,7 @@ namespace GalaxyCheck.Runners.CheckAutomata
         internal CheckState<T> IncrementDiscards() => new CheckState<T>(
             Property,
             RequestedIterations,
+            ShrinkLimit,
             CompletedIterations,
             Discards + 1,
             Shrinks,
@@ -57,6 +62,7 @@ namespace GalaxyCheck.Runners.CheckAutomata
         internal CheckState<T> IncrementShrinks() => new CheckState<T>(
             Property,
             RequestedIterations,
+            ShrinkLimit,
             CompletedIterations,
             Discards,
             Shrinks + 1,
@@ -67,6 +73,7 @@ namespace GalaxyCheck.Runners.CheckAutomata
         internal CheckState<T> AddCounterexample(CounterexampleState<T> counterexampleState) => new CheckState<T>(
             Property,
             RequestedIterations,
+            ShrinkLimit,
             CompletedIterations,
             Discards,
             Shrinks,
@@ -77,6 +84,7 @@ namespace GalaxyCheck.Runners.CheckAutomata
         internal CheckState<T> WithNextGenParameters(GenParameters genParameters) => new CheckState<T>(
             Property,
             RequestedIterations,
+            ShrinkLimit,
             CompletedIterations,
             Discards,
             Shrinks,

--- a/src/GalaxyCheck/Runners/CheckAutomata/CounterexampleExplorationTransition.cs
+++ b/src/GalaxyCheck/Runners/CheckAutomata/CounterexampleExplorationTransition.cs
@@ -12,11 +12,11 @@ namespace GalaxyCheck.Runners.CheckAutomata
         ExplorationStage<Test<T>>.Counterexample CounterexampleExploration) : AbstractTransition<T>(State)
     {
         internal override AbstractTransition<T> NextTransition() => new InstanceNextExplorationStageTransition<T>(
-            State.IncrementShrinks(),
+            State,
             Instance,
             NextExplorations,
             CounterexampleState,
-            false);
+            IsFirstExplorationStage: false);
 
         public CounterexampleState<T> CounterexampleState => new CounterexampleState<T>(
             CounterexampleExploration.ExampleSpace.Map(ex => ex.Input),

--- a/src/GalaxyCheck/Runners/CheckAutomata/InstanceCompleteTransition.cs
+++ b/src/GalaxyCheck/Runners/CheckAutomata/InstanceCompleteTransition.cs
@@ -10,7 +10,7 @@ namespace GalaxyCheck.Runners.CheckAutomata
         IGenInstance<Test<T>> Instance,
         CounterexampleState<T>? CounterexampleState,
         bool WasDiscard,
-        bool WasReplay = false) : AbstractTransition<T>(State)
+        bool WasReplay) : AbstractTransition<T>(State)
     {
         internal override AbstractTransition<T> NextTransition() => WasDiscard == true
             ? NextStateOnDiscard(State, Instance)

--- a/src/GalaxyCheck/Runners/CheckAutomata/InstanceNextExplorationStageTransition.cs
+++ b/src/GalaxyCheck/Runners/CheckAutomata/InstanceNextExplorationStageTransition.cs
@@ -24,26 +24,39 @@ namespace GalaxyCheck.Runners.CheckAutomata
                     State,
                     Instance,
                     CounterexampleState,
-                    WasDiscard: false);
+                    WasDiscard: false,
+                    WasReplay: false);
             }
+
+            if (IsFirstExplorationStage == false && State.Shrinks >= State.ShrinkLimit)
+            {
+                return new InstanceCompleteTransition<T>(
+                    State,
+                    Instance,
+                    CounterexampleState,
+                    WasDiscard: false,
+                    WasReplay: false);
+            }
+
+            var state = IsFirstExplorationStage ? State : State.IncrementShrinks();
 
             return head.Match<AbstractTransition<T>>(
                 onCounterexampleExploration: (counterexampleExploration) =>
                     new CounterexampleExplorationTransition<T>(
-                        State,
+                        state,
                         Instance,
                         tail,
                         counterexampleExploration),
                 onNonCounterexampleExploration: (nonCounterexampleExploration) =>
                     new NonCounterexampleExplorationTransition<T>(
-                        State,
+                        state,
                         Instance,
                         tail,
                         nonCounterexampleExploration,
                         CounterexampleState),
                 onDiscardExploration: () => IsFirstExplorationStage
-                    ? new InstanceCompleteTransition<T>(State, Instance, CounterexampleState: null, WasDiscard: true)
-                    : new DiscardExplorationTransition<T>(State, Instance, tail, CounterexampleState));
+                    ? new InstanceCompleteTransition<T>(state, Instance, CounterexampleState: null, WasDiscard: true, WasReplay: false)
+                    : new DiscardExplorationTransition<T>(state, Instance, tail, CounterexampleState));
         }
     }
 }

--- a/src/GalaxyCheck/Runners/Sample.cs
+++ b/src/GalaxyCheck/Runners/Sample.cs
@@ -100,7 +100,7 @@ namespace GalaxyCheck.Runners.Sample
             int? size,
             bool? enableLinqInference)
         {
-            var gen = new AdvancedToGen<T>(advanced).ForAll(x =>
+            var gen = advanced.AsGen().ForAll(x =>
             {
                 if (x is Test test)
                 {
@@ -127,18 +127,6 @@ namespace GalaxyCheck.Runners.Sample
                 values,
                 checkResult.Discards,
                 checkResult.RandomnessConsumption);
-        }
-
-        private class AdvancedToGen<T> : IGen<T>
-        {
-            public AdvancedToGen(IGenAdvanced<T> advanced)
-            {
-                Advanced = advanced;
-            }
-
-            public IGenAdvanced<T> Advanced { get; }
-
-            IGenAdvanced IGen.Advanced => Advanced;
         }
     }
 }

--- a/tests/GalaxyCheck.Tests.V2/ExampleSpaceExtensions.cs
+++ b/tests/GalaxyCheck.Tests.V2/ExampleSpaceExtensions.cs
@@ -55,13 +55,16 @@ namespace Tests.V2
             }
         }
 
-        public static IEnumerable<T> Traverse<T>(this IExampleSpace<T> exampleSpace)
+        public static IEnumerable<T> Traverse<T>(this IExampleSpace<T> exampleSpace) =>
+            exampleSpace.TraverseExamples().Select(example => example.Value);
+
+        public static IEnumerable<IExample<T>> TraverseExamples<T>(this IExampleSpace<T> exampleSpace)
         {
-            yield return exampleSpace.Current.Value;
+            yield return exampleSpace.Current;
 
             foreach (var exampleSubSpace in exampleSpace.Subspace)
             {
-                foreach (var subExample in Traverse(exampleSubSpace))
+                foreach (var subExample in TraverseExamples(exampleSubSpace))
                 {
                     yield return subExample;
                 }

--- a/tests/GalaxyCheck.Tests.V2/GenTests/ConstantTests/AboutConstant.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenTests/ConstantTests/AboutConstant.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using GalaxyCheck;
+using GalaxyCheck.Internal.ExampleSpaces;
 using NebulaCheck;
 using NebulaCheck.Xunit;
 using System.Linq;
@@ -21,13 +22,13 @@ namespace Tests.V2.GenTests.ConstantTests
 
                 var traversal = gen.Advanced
                     .SampleOneExampleSpace(seed: seed, size: size)
-                    .Traverse()
+                    .TraverseExamples()
                     .Take(100)
                     .ToList();
 
                 traversal
                     .Should().ContainSingle()
-                    .Subject.Should().BeEquivalentTo(value);
+                    .Subject.Should().BeEquivalentTo(new Example<object>(ExampleId.Empty, value, 0));
             });
 
         [Property]

--- a/tests/GalaxyCheck.Tests.V2/RunnerTests/AssertTests/__snapshots__/Snapshots.Snapshot_AssertFailure_IntLessThanEquals.snap
+++ b/tests/GalaxyCheck.Tests.V2/RunnerTests/AssertTests/__snapshots__/Snapshots.Snapshot_AssertFailure_IntLessThanEquals.snap
@@ -1,4 +1,4 @@
-﻿Falsified after 67 tests (55 shrinks)
+﻿Falsified after 67 tests (162 shrinks)
 Reproduction: H4sIAAAAAAAACjMyMDYwMDEyMjXSMzfRM7QywAkNrYysjK1MrMyA0MLKDADOoFSmOQAAAA==
 Counterexample: 1000
 

--- a/tests/GalaxyCheck.Tests.V2/RunnerTests/AssertTests/__snapshots__/Snapshots.Snapshot_AssertFailure_IntLessThanEquals_BinaryProperty.snap
+++ b/tests/GalaxyCheck.Tests.V2/RunnerTests/AssertTests/__snapshots__/Snapshots.Snapshot_AssertFailure_IntLessThanEquals_BinaryProperty.snap
@@ -1,4 +1,4 @@
-﻿Falsified after 60 tests (12 shrinks)
+﻿Falsified after 60 tests (55 shrinks)
 Reproduction: H4sIAAAAAAAACg3CgREAIAgDsY04ShXx9x9ML6l0y9I49g2RiMIsNudr5gEXagBOIwAAAA==
 Counterexample:
     [0] = 1000

--- a/tests/GalaxyCheck.Tests.V2/RunnerTests/CheckTests/AboutShrinkLimit.cs
+++ b/tests/GalaxyCheck.Tests.V2/RunnerTests/CheckTests/AboutShrinkLimit.cs
@@ -1,0 +1,55 @@
+﻿using FluentAssertions;
+using GalaxyCheck;
+using NebulaCheck;
+using NebulaCheck.Xunit;
+using System.Linq;
+using Xunit;
+using Gen = NebulaCheck.Gen;
+using Property = NebulaCheck.Property;
+using Test = NebulaCheck.Test;
+
+namespace Tests.V2.RunnerTests.CheckTests
+{
+    public class AboutShrinkLimit
+    {
+        private static readonly GalaxyCheck.IGen<int> InfinitelyShrinkableGen =
+            GalaxyCheck.Gen.Constant(0).Advanced.Unfold((x) => new[] { x + 1 });
+
+        [Property]
+        public NebulaCheck.IGen<Test> IfTheShrinkLimitIsZero_ThePropertyCanStillBeFalsified() =>
+            from gen in DomainGen.Gen()
+            from shrinkLimit in Gen.Int32().LessThanEqual(0)
+            from seed in DomainGen.Seed()
+            select Property.ForThese(() =>
+            {
+                var property = gen.ForAll(_ => false);
+
+                var result = property.Check(seed: seed, shrinkLimit: shrinkLimit);
+
+                result.Falsified.Should().BeTrue();
+            });
+
+        [Property]
+        public NebulaCheck.IGen<Test> ItShrinksToTheGivenLimit() =>
+            from shrinkLimit in Gen.Int32().Between(0, 100)
+            from seed in DomainGen.Seed()
+            select Property.ForThese(() =>
+            {
+                var property = InfinitelyShrinkableGen.ForAll(_ => false);
+
+                var result = property.Check(seed: seed, shrinkLimit: shrinkLimit);
+
+                result.Shrinks.Should().Be(shrinkLimit);
+            });
+
+        [Fact]
+        public void TheDefaultShrinkLimitIsFiveHundred()
+        {
+            var property = InfinitelyShrinkableGen.ForAll(_ => false);
+
+            var result = property.Check(seed: 0);
+
+            result.Shrinks.Should().Be(500);
+        }
+    }
+}


### PR DESCRIPTION
- Decouples creating a primitive gen from unfolding the example space (this test needed to unfold late)
- Fixes that shrink count, it was only counting counterexample shrinks (should also count non-counterexamples and discards)
- Adds AsGen() operator, which converts a GenAdvanced to a Gen