### PR TITLE
🌍 #151 Gen.List() produces IReadOnlyLists instead of ImmutableLists now

### DIFF
--- a/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenFactories/ListAutoGenHandler.cs
+++ b/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenFactories/ListAutoGenHandler.cs
@@ -44,8 +44,11 @@ namespace GalaxyCheck.Gens.AutoGenHelpers.AutoGenFactories
                 { typeof(IList<>), nameof(CreateListGen) },
             };
 
-        private static IGen<List<T>> CreateListGen<T>(IGen<T> elementGen) => CreateImmutableListGen(elementGen).Select(x => x.ToList());
+        private static IGen<IReadOnlyList<T>> CreateIReadOnlyListGen<T>(IGen<T> elementGen) => elementGen.ListOf();
 
-        private static IGen<ImmutableList<T>> CreateImmutableListGen<T>(IGen<T> elementGen) => elementGen.ListOf();
+        private static IGen<List<T>> CreateListGen<T>(IGen<T> elementGen) => CreateIReadOnlyListGen(elementGen).Select(x => x.ToList());
+
+        private static IGen<ImmutableList<T>> CreateImmutableListGen<T>(IGen<T> elementGen) =>
+            CreateIReadOnlyListGen(elementGen).Select(x => x.ToImmutableList());
     }
 }

--- a/src/GalaxyCheck/Gens/ListGen.cs
+++ b/src/GalaxyCheck/Gens/ListGen.cs
@@ -69,7 +69,7 @@ namespace GalaxyCheck.Gens
     using System.Collections.Immutable;
     using System.Linq;
 
-    public interface IListGen<T> : IGen<ImmutableList<T>>
+    public interface IListGen<T> : IGen<IReadOnlyList<T>>
     {
         /// <summary>
         /// Constrains the generator so that it only produces lists with the given count.
@@ -99,7 +99,7 @@ namespace GalaxyCheck.Gens
         IListGen<T> WithCountBias(Gen.Bias bias);
     }
 
-    internal class ListGen<T> : BaseGen<ImmutableList<T>>, IListGen<T>
+    internal class ListGen<T> : BaseGen<IReadOnlyList<T>>, IListGen<T>
     {
         private abstract record ListGenCountConfig
         {
@@ -163,7 +163,7 @@ namespace GalaxyCheck.Gens
             return new ListGen<T>(newConfig, _elementGen);
         }
 
-        protected override IEnumerable<IGenIteration<ImmutableList<T>>> Run(GenParameters parameters) =>
+        protected override IEnumerable<IGenIteration<IReadOnlyList<T>>> Run(GenParameters parameters) =>
             BuildGen(_config, _elementGen).Advanced.Run(parameters);
 
         private static IGen<ImmutableList<T>> BuildGen(ListGenConfig config, IGen<T> elementGen)

--- a/src/GalaxyCheck/Gens/StringGen.cs
+++ b/src/GalaxyCheck/Gens/StringGen.cs
@@ -54,7 +54,6 @@ namespace GalaxyCheck.Gens
     using GalaxyCheck.Gens.Parameters;
     using System;
     using System.Collections.Generic;
-    using System.Collections.Immutable;
     using System.Linq;
 
     public interface IStringGen : IGen<string>
@@ -229,10 +228,10 @@ namespace GalaxyCheck.Gens
             }
         }
 
-        private static IGen<ImmutableList<char>> CreateListGen(IGen<char> charGen, StringGenLengthConfig? lengthConfig, Gen.Bias? lengthBias)
+        private static IGen<IReadOnlyList<char>> CreateListGen(IGen<char> charGen, StringGenLengthConfig? lengthConfig, Gen.Bias? lengthBias)
         {
-            static IGen<ImmutableList<char>> Error(string message) =>
-                Gen.Advanced.Error<ImmutableList<char>>(nameof(StringGen), message);
+            static IGen<IReadOnlyList<char>> Error(string message) =>
+                Gen.Advanced.Error<IReadOnlyList<char>>(nameof(StringGen), message);
 
             lengthConfig ??= new StringGenLengthConfig.Ranged(null, null);
 

--- a/tests/GalaxyCheck.Tests.V2/GenTests/AutoGenTests/AboutGeneratingLists.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenTests/AutoGenTests/AboutGeneratingLists.cs
@@ -57,7 +57,7 @@ namespace Tests.V2.GenTests.AutoGenTests
                     AboutGeneratingLists.SampleTraversal(gen, seed, size);
 
                 var gen0 = GalaxyCheck.Gen.Auto<ImmutableList<int>>();
-                var gen1 = GalaxyCheck.Gen.Int32().ListOf();
+                var gen1 = GalaxyCheck.Gen.Int32().ListOf().Select(x => x.ToImmutableList());
 
                 var sample0 = SampleTraversal(gen0);
                 var sample1 = SampleTraversal(gen1);
@@ -75,7 +75,7 @@ namespace Tests.V2.GenTests.AutoGenTests
                     AboutGeneratingLists.SampleTraversal(gen, seed, size);
 
                 var gen0 = GalaxyCheck.Gen.Auto<IList<int>>();
-                var gen1 = GalaxyCheck.Gen.Int32().ListOf();
+                var gen1 = GalaxyCheck.Gen.Int32().ListOf().Select(x => x.ToList());
 
                 var sample0 = SampleTraversal(gen0);
                 var sample1 = SampleTraversal(gen1);

--- a/tests/GalaxyCheck.Tests.V2/GenTests/InfiniteGenTests/AboutValueProduction.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenTests/InfiniteGenTests/AboutValueProduction.cs
@@ -1,7 +1,7 @@
 ﻿using FluentAssertions;
 using GalaxyCheck;
 using NebulaCheck;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Linq;
 using Gen = NebulaCheck.Gen;
 using Property = NebulaCheck.Property;
@@ -42,13 +42,13 @@ namespace Tests.V2.GenTests.InfiniteGenTests
             from size in DomainGen.Size()
             select Property.ForThese(() =>
             {
-                ImmutableList<object> Sample(GalaxyCheck.IGen<ImmutableList<object>> gen, int seed) =>
+                IReadOnlyList<object> Sample(GalaxyCheck.IGen<IReadOnlyList<object>> gen, int seed) =>
                     gen.SampleOne(seed: seed, size: size);
 
                 var gen = elementGen.InfiniteOf();
 
                 var listGen = elementGen.ListOf().WithCount(count);
-                var infiniteGen = elementGen.InfiniteOf().Select(enumerable => enumerable.Take(count).ToImmutableList());
+                var infiniteGen = elementGen.InfiniteOf().Select(enumerable => enumerable.Take(count).ToList());
 
                 var listSample = Sample(listGen, SeedUtility.Fork(seed));
                 var infiniteSample = Sample(infiniteGen, seed);

--- a/tests/GalaxyCheck.Tests.V2/GenTests/ListGenTests/AboutDefaults.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenTests/ListGenTests/AboutDefaults.cs
@@ -2,7 +2,6 @@
 using GalaxyCheck;
 using NebulaCheck;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Property = NebulaCheck.Property;
 using Test = NebulaCheck.Test;
@@ -18,7 +17,7 @@ namespace Tests.V2.GenTests.ListGenTests
             from size in DomainGen.Size()
             select Property.ForThese(() =>
             {
-                List<ImmutableList<object>> SampleTraversal(GalaxyCheck.IGen<ImmutableList<object>> gen) =>
+                List<IReadOnlyList<object>> SampleTraversal(GalaxyCheck.IGen<IReadOnlyList<object>> gen) =>
                     AboutDefaults.SampleTraversal(gen, seed: seed, size: size);
 
                 var gen0 = elementGen.ListOf();
@@ -34,7 +33,7 @@ namespace Tests.V2.GenTests.ListGenTests
             from size in DomainGen.Size()
             select Property.ForThese(() =>
             {
-                List<ImmutableList<object>> SampleTraversal(GalaxyCheck.IGen<ImmutableList<object>> gen) =>
+                List<IReadOnlyList<object>> SampleTraversal(GalaxyCheck.IGen<IReadOnlyList<object>> gen) =>
                     AboutDefaults.SampleTraversal(gen, seed: seed, size: size);
 
                 var gen0 = elementGen.ListOf();
@@ -50,7 +49,7 @@ namespace Tests.V2.GenTests.ListGenTests
             from size in DomainGen.Size()
             select Property.ForThese(() =>
             {
-                List<ImmutableList<object>> SampleTraversal(GalaxyCheck.IGen<ImmutableList<object>> gen) =>
+                List<IReadOnlyList<object>> SampleTraversal(GalaxyCheck.IGen<IReadOnlyList<object>> gen) =>
                     AboutDefaults.SampleTraversal(gen, seed: seed, size: size);
 
                 var gen0 = elementGen.ListOf();
@@ -59,7 +58,7 @@ namespace Tests.V2.GenTests.ListGenTests
                 SampleTraversal(gen0).Should().BeEquivalentTo(SampleTraversal(gen1));
             });
 
-        private static List<ImmutableList<object>> SampleTraversal(GalaxyCheck.IGen<ImmutableList<object>> gen, int seed, int size) => gen.Advanced
+        private static List<IReadOnlyList<object>> SampleTraversal(GalaxyCheck.IGen<IReadOnlyList<object>> gen, int seed, int size) => gen.Advanced
             .SampleOneExampleSpace(seed: seed, size: size)
             .Traverse()
             .Take(100)


### PR DESCRIPTION
#151

There is less baggage attached to an IReadOnlyList, it's a much tighter interface.