### PR TITLE
🌍 #24 Re-simplify error structure, ensure that all errors from AutoGen are re-routed to ParametersGen

### DIFF
--- a/src/GalaxyCheck/Gens/AutoGen.cs
+++ b/src/GalaxyCheck/Gens/AutoGen.cs
@@ -158,8 +158,7 @@ namespace GalaxyCheck.Gens
             if (errorExpression != null)
             {
                 return Error(
-                    $"expression '{errorExpression}' was invalid, an overridding expression may only contain member access",
-                    new { });
+                    $"expression '{errorExpression}' was invalid, an overridding expression may only contain member access");
             }
 
             var context = AutoGenHandlerContext.Create(typeof(T));
@@ -168,11 +167,6 @@ namespace GalaxyCheck.Gens
                 .Cast<T>();
         }
 
-        private static IGen<T> Error(string message, object error) =>
-            Gen.Advanced.Error<T>(nameof(AutoGen<T>), message, error);
+        private static IGen<T> Error(string message) => Gen.Advanced.Error<T>(nameof(AutoGen<T>), message);
     }
-
-    internal record AutoGenTypeRegistrationMismatchError(
-        Type GenTypeArgument,
-        Type RegisteredType);
 }

--- a/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenBuilder.cs
+++ b/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenBuilder.cs
@@ -14,10 +14,10 @@ namespace GalaxyCheck.Gens.AutoGenHelpers
             ErrorFactory errorFactory,
             AutoGenHandlerContext context)
         {
-            ContextualErrorFactory contextualErrorFactory = (message, error, context) =>
+            ContextualErrorFactory contextualErrorFactory = (message, context) =>
             {
                 var suffix = context.Members.Count() == 1 ? "" : $" at path '{context.MemberPath}'";
-                return errorFactory(message + suffix, error);
+                return errorFactory(message + suffix);
             };
 
             var genFactoriesByPriority = new List<IAutoGenHandler>

--- a/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenHandlers/CompositeAutoGenHandler.cs
+++ b/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenHandlers/CompositeAutoGenHandler.cs
@@ -24,7 +24,7 @@ namespace GalaxyCheck.Gens.AutoGenHelpers.AutoGenHandlers
         {
             if (context.TypeHistory.Skip(1).Any(t => t == type))
             {
-                return _errorFactory($"detected circular reference on type '{type}'", new { }, context);
+                return _errorFactory($"detected circular reference on type '{type}'", context);
             }
 
             var gen = _genHandlersByPriority
@@ -34,13 +34,10 @@ namespace GalaxyCheck.Gens.AutoGenHelpers.AutoGenHandlers
 
             if (gen == null)
             {
-                return _errorFactory($"could not resolve type '{type}'", new { }, context);
+                return _errorFactory($"could not resolve type '{type}'", context);
             }
 
             return gen;
         }
-
-        private static string RenderPathDiagnostics(AutoGenHandlerContext context) =>
-            context.Members.Count() == 1 ? "" : $" at path '{context.MemberPath}'";
     }
 }

--- a/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenHandlers/DefaultConstructorAutoGenHandler.cs
+++ b/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenHandlers/DefaultConstructorAutoGenHandler.cs
@@ -28,7 +28,7 @@ namespace GalaxyCheck.Gens.AutoGenHelpers.AutoGenHandlers
             {
                 var innerEx = ex.InnerException;
                 var message = $"'{innerEx.GetType()}' was thrown while calling constructor with message '{innerEx.Message}'";
-                return _errorFactory(message, new { }, context);
+                return _errorFactory(message, context);
             }
 
             return Gen
@@ -47,7 +47,7 @@ namespace GalaxyCheck.Gens.AutoGenHelpers.AutoGenHandlers
                         {
                             var innerEx = ex.InnerException;
                             var message = $"'{innerEx.GetType()}' was thrown while setting property with message '{innerEx.Message}'";
-                            return _errorFactory(message, new { }, context).Cast<object>();
+                            return _errorFactory(message, context).Cast<object>();
                         }
                     }
 

--- a/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenHandlers/NonDefaultConstructorAutoGenHandler.cs
+++ b/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenHandlers/NonDefaultConstructorAutoGenHandler.cs
@@ -38,7 +38,7 @@ namespace GalaxyCheck.Gens.AutoGenHelpers.AutoGenHandlers
                     {
                         var innerEx = ex.InnerException;
                         var message = $"'{innerEx.GetType()}' was thrown while calling constructor with message '{innerEx.Message}'";
-                        return _errorFactory(message, new { }, context).Cast<object>();
+                        return _errorFactory(message, context).Cast<object>();
                     }
                 });
         }

--- a/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenHandlers/RegistryAutoGenHandler.cs
+++ b/src/GalaxyCheck/Gens/AutoGenHelpers/AutoGenHandlers/RegistryAutoGenHandler.cs
@@ -31,7 +31,6 @@ namespace GalaxyCheck.Gens.AutoGenHelpers.AutoGenHandlers
                 {
                     return _errorFactory(
                         $"type '{genTypeArgument}' was not assignable to the type it was registered to, '{registeredType}'",
-                        new AutoGenTypeRegistrationMismatchError(genTypeArgument, registeredType),
                         context);
                 }
             }

--- a/src/GalaxyCheck/Gens/AutoGenHelpers/ErrorFactory.cs
+++ b/src/GalaxyCheck/Gens/AutoGenHelpers/ErrorFactory.cs
@@ -1,6 +1,6 @@
 ﻿namespace GalaxyCheck.Gens.AutoGenHelpers
 {
-    internal delegate IGen ErrorFactory(string message, object error);
+    internal delegate IGen ErrorFactory(string message);
 
-    internal delegate IGen ContextualErrorFactory(string message, object error, AutoGenHandlerContext context);
+    internal delegate IGen ContextualErrorFactory(string message, AutoGenHandlerContext context);
 }

--- a/src/GalaxyCheck/Gens/ErrorGen.cs
+++ b/src/GalaxyCheck/Gens/ErrorGen.cs
@@ -15,19 +15,18 @@
             /// </summary>
             /// <param name="genName">The name of the generator where the error was detected.</param>
             /// <param name="message">A message explaining what this error is, and what it might have been caused by.
-            /// <param name="error">An optional object representing the error.</param>
             /// </param>
             /// <returns>A new generator that errors when it runs.</returns>
-            public static IGen<T> Error<T>(string genName, string message, object? error = null) =>
-                new ErrorGen<T>(genName, message, error ?? new object());
+            public static IGen<T> Error<T>(string genName, string message) =>
+                new ErrorGen<T>(genName, message);
 
-            internal static IGen Error(Type type, string genName, string message, object? error = null)
+            internal static IGen Error(Type type, string genName, string message)
             {
                 var genericErrorGen = typeof(Advanced)
                     .GetMethod(nameof(Advanced.Error))
                     .MakeGenericMethod(type);
 
-                return (IGen)genericErrorGen.Invoke(null, new object?[] { genName, message, error });
+                return (IGen)genericErrorGen.Invoke(null, new object?[] { genName, message });
             }
         }
     }
@@ -45,20 +44,18 @@ namespace GalaxyCheck.Gens
     {
         private readonly string _genName;
         private readonly string _message;
-        private readonly object _error;
 
-        public ErrorGen(string genName, string message, object error)
+        public ErrorGen(string genName, string message)
         {
             _genName = genName;
             _message = message;
-            _error = error;
         }
 
         protected override IEnumerable<IGenIteration<T>> Run(GenParameters parameters)
         {
             while (true)
             {
-                yield return GenIterationFactory.Error<T>(parameters, parameters, _genName, _message, _error);
+                yield return GenIterationFactory.Error<T>(parameters, parameters, _genName, _message);
             }
         }
     }

--- a/src/GalaxyCheck/Gens/Internal/Iterations/GenIterationExtensions.cs
+++ b/src/GalaxyCheck/Gens/Internal/Iterations/GenIterationExtensions.cs
@@ -9,7 +9,7 @@ namespace GalaxyCheck.Gens.Internal.Iterations
             this IGenIteration<TSource> iteration) => iteration.Match<Either<IGenInstance<TSource>, IGenIteration<TNonInstance>>>(
                 onInstance: instance => new Left<IGenInstance<TSource>, IGenIteration<TNonInstance>>(instance),
                 onError: error => new Right<IGenInstance<TSource>, IGenIteration<TNonInstance>>(
-                    GenIterationFactory.Error<TNonInstance>(error.ReplayParameters, error.NextParameters, error.GenName, error.Message, error.Error)),
+                    GenIterationFactory.Error<TNonInstance>(error.ReplayParameters, error.NextParameters, error.GenName, error.Message)),
                 onDiscard: discard => new Right<IGenInstance<TSource>, IGenIteration<TNonInstance>>(
                     GenIterationFactory.Discard<TNonInstance>(discard.ReplayParameters, discard.NextParameters)));
 

--- a/src/GalaxyCheck/Gens/Internal/Iterations/GenIterationFactory.cs
+++ b/src/GalaxyCheck/Gens/Internal/Iterations/GenIterationFactory.cs
@@ -30,7 +30,7 @@ namespace GalaxyCheck.Gens.Internal.Iterations
 
             IGenData IGenIteration.Data => Data.Match<IGenData>(
                 onInstance: instanceData => GenData.InstanceData(instanceData.ExampleSpace, instanceData.ExampleSpaceHistory),
-                onError: errorData => GenData.ErrorData(errorData.GenName, errorData.Message, errorData.Error),
+                onError: errorData => GenData.ErrorData(errorData.GenName, errorData.Message),
                 onDiscard: discardData => GenData.DiscardData());
 
             public TResult Match<TResult>(
@@ -71,8 +71,6 @@ namespace GalaxyCheck.Gens.Internal.Iterations
                 public string GenName => Data.Error!.GenName;
 
                 public string Message => Data.Error!.Message;
-
-                public object Error => Data.Error!.Error;
             }
 
             private record GenDiscard<U> : GenIteration<U>, IGenDiscard<U>
@@ -116,11 +114,10 @@ namespace GalaxyCheck.Gens.Internal.Iterations
             GenParameters replayParameters,
             GenParameters nextParameters,
             string genName,
-            string message,
-            object error) => new GenIteration<T>(
+            string message) => new GenIteration<T>(
                 replayParameters,
                 nextParameters,
-                GenData<T>.ErrorData(genName, message, error));
+                GenData<T>.ErrorData(genName, message));
 
         public static IGenIteration<T> Discard<T>(
             GenParameters replayParameters,

--- a/src/GalaxyCheck/Gens/Iterations/GenIteration.cs
+++ b/src/GalaxyCheck/Gens/Iterations/GenIteration.cs
@@ -40,8 +40,6 @@ namespace GalaxyCheck.Gens.Iterations
         string GenName { get; }
 
         string Message { get; }
-
-        object Error { get; }
     }
 
     public interface IGenDiscardData
@@ -52,7 +50,7 @@ namespace GalaxyCheck.Gens.Iterations
         IExampleSpace ExampleSpace,
         IEnumerable<IExampleSpace> ExampleSpaceHistory) : IGenInstanceData;
 
-    public record GenErrorData(string GenName, string Message, object Error) : IGenErrorData;
+    public record GenErrorData(string GenName, string Message) : IGenErrorData;
 
     public record GenDiscardData() : IGenDiscardData;
 
@@ -67,10 +65,10 @@ namespace GalaxyCheck.Gens.Iterations
                 Discard = null
             };
 
-        public static GenData ErrorData(string genName, string message, object error) => new GenData
+        public static GenData ErrorData(string genName, string message) => new GenData
         {
             Instance = null,
-            Error = new GenErrorData(genName, message, error),
+            Error = new GenErrorData(genName, message),
             Discard = null
         };
 

--- a/src/GalaxyCheck/Gens/Iterations/Generic/GenIteration.cs
+++ b/src/GalaxyCheck/Gens/Iterations/Generic/GenIteration.cs
@@ -62,7 +62,7 @@ namespace GalaxyCheck.Gens.Iterations.Generic
         IExampleSpace IGenInstanceData.ExampleSpace => ExampleSpace;
     }
 
-    public record GenErrorData(string GenName, string Message, object Error) : IGenErrorData;
+    public record GenErrorData(string GenName, string Message) : IGenErrorData;
 
     public record GenDiscardData() : IGenDiscardData;
 
@@ -77,10 +77,10 @@ namespace GalaxyCheck.Gens.Iterations.Generic
                 Discard = null
             };
 
-        public static GenData<T> ErrorData(string genName, string message, object error) => new GenData<T>
+        public static GenData<T> ErrorData(string genName, string message) => new GenData<T>
         {
             Instance = null,
-            Error = new GenErrorData(genName, message, error),
+            Error = new GenErrorData(genName, message),
             Discard = null
         };
 

--- a/src/GalaxyCheck/Gens/ParametersGen.cs
+++ b/src/GalaxyCheck/Gens/ParametersGen.cs
@@ -92,8 +92,7 @@ namespace GalaxyCheck.Gens
                 gen = Gen.Advanced.Error(
                     parameterInfo.ParameterType,
                     nameof(ParametersGen),
-                    $"parameter '{parameterInfo.Name}' has multiple {nameof(GenProviderAttribute)}s (unsupported)",
-                    new { });
+                    $"multiple {nameof(GenProviderAttribute)}s is unsupported");
                 return true;
             }
 
@@ -103,18 +102,9 @@ namespace GalaxyCheck.Gens
 
         private static Iterations.IGenErrorData SelectParameterError(ParameterInfo parameterInfo, Iterations.IGenErrorData error)
         {
-            return error.Error switch
-            {
-                AutoGenTypeRegistrationMismatchError typeRegistrationMismatchError => new GenErrorData(
-                    nameof(ParametersGen),
-                    $"unable to generate value for parameter '{parameterInfo.Name}', '{typeRegistrationMismatchError.GenTypeArgument}' is not assignable to '{typeRegistrationMismatchError.RegisteredType}'",
-                    new ParametersGenTypeMismatchError(typeRegistrationMismatchError.GenTypeArgument, typeRegistrationMismatchError.GenTypeArgument)),
-                _ => error
-            };
+            return new GenErrorData(
+                nameof(ParametersGen),
+                $"unable to generate value for parameter '{parameterInfo.Name}', {error.Message}");
         }
     }
-
-    internal record ParametersGenTypeMismatchError(
-        Type GenTypeArgument,
-        Type RegisteredType);
 }

--- a/src/GalaxyCheck/Operators/Cast.cs
+++ b/src/GalaxyCheck/Operators/Cast.cs
@@ -20,8 +20,7 @@ namespace GalaxyCheck
                         iteration.ReplayParameters,
                         iteration.NextParameters,
                         error.GenName,
-                        error.Message,
-                        error.Error),
+                        error.Message),
                     onDiscard: discard => GenIterationFactory.Discard<T>(
                         iteration.ReplayParameters,
                         iteration.NextParameters))));

--- a/src/GalaxyCheck/Operators/SelectError.cs
+++ b/src/GalaxyCheck/Operators/SelectError.cs
@@ -17,8 +17,7 @@ namespace GalaxyCheck
                     error.ReplayParameters,
                     error.NextParameters,
                     selectedErrorData.GenName,
-                    selectedErrorData.Message,
-                    selectedErrorData.Error);
+                    selectedErrorData.Message);
             }
 
             GenIterationTransformation<T, T> transformation = (iteration) =>

--- a/src/GalaxyCheck/Operators/SelectMany.cs
+++ b/src/GalaxyCheck/Operators/SelectMany.cs
@@ -117,8 +117,7 @@ namespace GalaxyCheck
                                     iteration.ReplayParameters,
                                     innerIteration.NextParameters,
                                     innerError.GenName,
-                                    innerError.Message,
-                                    innerError.Error),
+                                    innerError.Message),
                                 onDiscard: innerDiscard => GenIterationFactory.Discard<TResult>(
                                     iteration.ReplayParameters,
                                     innerIteration.NextParameters));

--- a/src/GalaxyCheck/Operators/Unfold.cs
+++ b/src/GalaxyCheck/Operators/Unfold.cs
@@ -18,7 +18,7 @@ namespace GalaxyCheck
                 value,
                 shrinkValue.Invoke,
                 measureValue == null ? MeasureFunc.Unmeasured<T>() : measureValue!.Invoke,
-                identifyValue == null ? IdentifyFuncs.Default<T>() : value0 => ExampleId.Primitive(identifyValue(value0))));
+                identifyValue == null ? IdentifyFuncs.Default<T>() : value0 => ExampleId.Primitive(identifyValue!(value0))));
         }
 
         public static IGen<T> Unfold<T>(

--- a/tests/GalaxyCheck.Tests.V2/GenTests/ParameterGenTests/AboutValidation.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenTests/ParameterGenTests/AboutValidation.cs
@@ -15,8 +15,13 @@ namespace Tests.V2.GenTests.ParameterGenTests
 
         private static void PropertyWhereTypeOfGenIsNotAssignableToTypeOfParameter([StringGen] int x) { }
 
+        /// <summary>
+        /// ParametersGen uses AutoGen to generate individual parameters. We should just check that one error message
+        /// that we know originates in AutoGen is routed through correctly. Then we can assume that all errors from
+        /// AutoGen are handled in the same fashion.
+        /// </summary>
         [Fact]
-        public void ItErrorsWhenTypeOfGenIsNotAssignableToTypeOfParameter()
+        public void ItErrorsWhenTheAutoGenMightHaveErrored()
         {
             var gen = Gen.Parameters(GetMethod(nameof(PropertyWhereTypeOfGenIsNotAssignableToTypeOfParameter)));
 
@@ -24,7 +29,7 @@ namespace Tests.V2.GenTests.ParameterGenTests
 
             test.Should()
                 .Throw<Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator ParametersGen: unable to generate value for parameter 'x', 'System.String' is not assignable to 'System.Int32'");
+                .WithMessage("Error while running generator ParametersGen: unable to generate value for parameter 'x', type 'System.String' was not assignable to the type it was registered to, 'System.Int32'");
         }
 
         private class AnotherStringGenAttribute : GenProviderAttribute
@@ -43,7 +48,7 @@ namespace Tests.V2.GenTests.ParameterGenTests
 
             test.Should()
                 .Throw<Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator ParametersGen: parameter 'x' has multiple GenProviderAttributes (unsupported)");
+                .WithMessage("Error while running generator ParametersGen: unable to generate value for parameter 'x', multiple GenProviderAttributes is unsupported");
         }
 
         private static MethodInfo GetMethod(string name)


### PR DESCRIPTION
The extra complexity of custom error symbols is not justifiable at this stage.