### PR TITLE
🌍 #218 #219 Restructure some of the foundational gens

### DIFF
--- a/src/GalaxyCheck.Tests/Gen/GenericOperators/AboutWhere.cs
+++ b/src/GalaxyCheck.Tests/Gen/GenericOperators/AboutWhere.cs
@@ -46,7 +46,7 @@ namespace Tests.Gen.GenericOperators
         {
             TestWithSeed(seed =>
             {
-                var gen = GC.Gen.Advanced.Primitive((useNextInt, size) => size.Value).Where(size => size > 10);
+                var gen = GC.Gen.Create(parameters => (parameters.Size.Value, parameters)).Where(size => size > 10);
 
                 var values = gen.Sample(
                     seed: seed,

--- a/src/GalaxyCheck/Gens/ConstantGen.cs
+++ b/src/GalaxyCheck/Gens/ConstantGen.cs
@@ -7,6 +7,6 @@
         /// </summary>
         /// <param name="value">The constant value the generator should produce.</param>
         /// <returns>The new generator.</returns>
-        public static IGen<T> Constant<T>(T value) => Advanced.Primitive((useNextInt, size) => value);
+        public static IGen<T> Constant<T>(T value) => Create(parameters => (value, parameters));
     }
 }

--- a/src/GalaxyCheck/Gens/CreateGen.cs
+++ b/src/GalaxyCheck/Gens/CreateGen.cs
@@ -1,0 +1,46 @@
+﻿using GalaxyCheck.ExampleSpaces;
+using GalaxyCheck.Gens;
+using GalaxyCheck.Gens.Internal;
+using GalaxyCheck.Gens.Internal.Iterations;
+using GalaxyCheck.Gens.Iterations.Generic;
+using GalaxyCheck.Gens.Parameters;
+using System;
+using System.Collections.Generic;
+
+namespace GalaxyCheck
+{
+    public static partial class Gen
+    {
+        /// <summary>
+        /// Generates instances of the given type, using the default <see cref="IGenFactory"/>. The auto-generator
+        /// can not be configured as precisely as more specialized generators can be, but it can create complex types
+        /// with minimal configuration through reflection.
+        /// </summary>
+        /// <returns>A generator for the given type.</returns>
+        public static IReflectedGen<T> Create<T>() => Factory().Create<T>();
+
+        /// <summary>
+        /// Generates instances by the given function. Instances will not shrink by default, to enable shrinking on the
+        /// generator, use <see cref="Extensions.Unfold{T}(IGen{T}, Func{T, IExampleSpace{T}})"/>. The function must
+        /// return the parameters to be used in the next iteration, considering any randomness that was used in this
+        /// to generate this iteration.
+        /// </summary>
+        /// <param name="func">The generator function.</param>
+        /// <returns>A generator for the given type, create by the given function.</returns>
+        public static IGen<T> Create<T>(Func<GenParameters, (T value, GenParameters nextParameters)> func)
+        {
+            IEnumerable<IGenIteration<T>> GenFunc(GenParameters parameters)
+            {
+                while (true)
+                {
+                    var replayParameters = parameters;
+                    var (value, nextParameters) = func(replayParameters);
+                    parameters = nextParameters;
+                    yield return GenIterationFactory.Instance(replayParameters, nextParameters, ExampleSpaceFactory.Singleton(value));
+                }
+            }
+
+            return new FunctionalGen<T>(parameters => GenFunc(parameters));
+        }
+    }
+}

--- a/src/GalaxyCheck/Gens/FactoryGen.cs
+++ b/src/GalaxyCheck/Gens/FactoryGen.cs
@@ -17,14 +17,6 @@ namespace GalaxyCheck
         /// </summary>
         /// <returns>A factory for auto-generators.</returns>
         public static IGenFactory Factory() => new GenFactory();
-
-        /// <summary>
-        /// Generates instances of the given type, using the default <see cref="IGenFactory"/>. The auto-generator
-        /// can not be configured as precisely as more specialized generators can be, but it can create complex types
-        /// with minimal configuration through reflection.
-        /// </summary>
-        /// <returns>A generator for the given type.</returns>
-        public static IReflectedGen<T> Create<T>() => Factory().Create<T>();
     }
 }
 

--- a/src/GalaxyCheck/Operators/Unfold.cs
+++ b/src/GalaxyCheck/Operators/Unfold.cs
@@ -9,12 +9,12 @@ namespace GalaxyCheck
     public static partial class Extensions
     {
         public static IGen<T> Unfold<T>(
-            this IGenAdvanced<T> advanced,
+            this IGen<T> gen,
             Func<T, IEnumerable<T>> shrinkValue,
             Func<T, decimal>? measureValue = null,
             Func<T, int>? identifyValue = null)
         {
-            return advanced.Unfold(value => ExampleSpaceFactory.Unfold(
+            return gen.Unfold(value => ExampleSpaceFactory.Unfold(
                 value,
                 shrinkValue.Invoke,
                 measureValue == null ? MeasureFunc.Unmeasured<T>() : measureValue!.Invoke,
@@ -22,7 +22,7 @@ namespace GalaxyCheck
         }
 
         public static IGen<T> Unfold<T>(
-            this IGenAdvanced<T> advanced,
+            this IGen<T> gen,
             Func<T, IExampleSpace<T>> unfolder)
         {
             GenInstanceTransformation<T, T> transformation = (instance) =>
@@ -34,9 +34,7 @@ namespace GalaxyCheck
                     instance.ExampleSpaceHistory);
             };
 
-            return advanced
-                .AsGen()
-                .TransformInstances(transformation);
+            return gen.TransformInstances(transformation);
         }
     }
 }

--- a/tests/GalaxyCheck.Tests.V2/RunnerTests/CheckTests/AboutShrinkLimit.cs
+++ b/tests/GalaxyCheck.Tests.V2/RunnerTests/CheckTests/AboutShrinkLimit.cs
@@ -12,7 +12,7 @@ namespace Tests.V2.RunnerTests.CheckTests
     public class AboutShrinkLimit
     {
         private static readonly GalaxyCheck.IGen<int> InfinitelyShrinkableGen =
-            GalaxyCheck.Gen.Constant(0).Advanced.Unfold((x) => new[] { x + 1 });
+            GalaxyCheck.Gen.Constant(0).Unfold((x) => new[] { x + 1 });
 
         [Property]
         public NebulaCheck.IGen<Test> IfTheShrinkLimitIsZero_ThePropertyCanStillBeFalsified() =>

--- a/tests/GalaxyCheck.Tests.V2/RunnerTests/CheckTests/AboutSizing.cs
+++ b/tests/GalaxyCheck.Tests.V2/RunnerTests/CheckTests/AboutSizing.cs
@@ -15,7 +15,7 @@ namespace Tests.V2.RunnerTests.CheckTests
             from seed in DomainGen.Seed()
             select Property.ForThese(() =>
             {
-                var property = GalaxyCheck.Gen.Advanced.Primitive((_, size) => size.Value).ForAll(x => x < 50);
+                var property = GalaxyCheck.Gen.Create(parameters => (parameters.Size.Value, parameters)).ForAll(x => x < 50);
 
                 var result = property.Check(iterations: iterations, seed: seed);
 
@@ -29,7 +29,7 @@ namespace Tests.V2.RunnerTests.CheckTests
             from seed in DomainGen.Seed()
             select Property.ForThese(() =>
             {
-                var property = GalaxyCheck.Gen.Advanced.Primitive((_, size) => size.Value).ForAll(x => x > 50);
+                var property = GalaxyCheck.Gen.Create(parameters => (parameters.Size.Value, parameters)).ForAll(x => x > 50);
 
                 var result = property.Check(iterations: iterations, seed: seed);
 

--- a/tests/GalaxyCheck.Tests.V2/RunnerTests/MinimumTests/AboutMinimumWithMetrics.cs
+++ b/tests/GalaxyCheck.Tests.V2/RunnerTests/MinimumTests/AboutMinimumWithMetrics.cs
@@ -20,7 +20,7 @@ namespace Tests.V2.RunnerTests.MinimumTests
             select Property.ForThese(() =>
             {
                 var minimum = gen
-                    .Advanced.Unfold(x => UnfoldToNumberOfShrinks(x, numberOfShrinks))
+                    .Unfold(x => UnfoldToNumberOfShrinks(x, numberOfShrinks))
                     .Advanced.MinimumWithMetrics(seed: seed);
 
                 minimum.Shrinks.Should().Be(numberOfShrinks);


### PR DESCRIPTION
- Moves Gen.Advanced.Unfold => Gen.Unfold
- Removes Gen.Advanced.Primitive API, in favour of another Gen.Create overload
- Reduces the reliance on new Gen.Create API, generators should prefer to use Gen.Int32() instead