### PR TITLE
🌍 #163 Generate sets with an unspecified count

### DIFF
--- a/tests/GalaxyCheck.Tests.V2/GenTests/SetGenTests/AboutExhaustion.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenTests/SetGenTests/AboutExhaustion.cs
@@ -1,0 +1,22 @@
+﻿using FluentAssertions;
+using GalaxyCheck;
+using NebulaCheck;
+using System;
+using static Tests.V2.DomainGenAttributes;
+
+namespace Tests.V2.GenTests.SetGenTests
+{
+    public class AboutExhaustion
+    {
+        [Property(Iterations = 10)]
+        public void ItExhaustsWhenGeneratingASetOfAnImpossibleSize([Seed] int seed, [Size] int size)
+        {
+            var elementGen = GalaxyCheck.Gen.Boolean();
+            var gen = GalaxyCheck.Gen.Set(elementGen).WithCount(3);
+
+            Action test = () => gen.SampleOne(seed: seed, size: size);
+
+            test.Should().Throw<GalaxyCheck.Exceptions.GenExhaustionException>();
+        }
+    }
+}

--- a/tests/GalaxyCheck.Tests.V2/GenTests/SetGenTests/AboutUnconstrainedGeneration.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenTests/SetGenTests/AboutUnconstrainedGeneration.cs
@@ -1,0 +1,25 @@
+﻿using FluentAssertions;
+using GalaxyCheck;
+using NebulaCheck;
+using System;
+using System.Linq;
+using static Tests.V2.DomainGenAttributes;
+
+namespace Tests.V2.GenTests.SetGenTests
+{
+    public class AboutUnconstrainedGeneration
+    {
+        [Property(Iterations = 10)]
+        public void ItCanGenerateABooleanSet([Seed] int seed, [Size] int size)
+        {
+            var elementGen = GalaxyCheck.Gen.Boolean();
+            var gen = GalaxyCheck.Gen
+                .Set(elementGen)
+                .Where(set => set.Count > 0); // Ensure it doesn't always return an empty set, without explicitly constraining it
+
+            var sample = gen.SampleOneTraversal(seed: seed, size: size);
+
+            sample.Should().OnlyContain(set => set.Distinct().SequenceEqual(set));
+        }
+    }
+}


### PR DESCRIPTION
This allows generator expressions like Gen.Boolean().SetOf() to complete. It short-circuits the strategy where we select a count and then generate to that count. This is because we might generate a count bigger than how big the set can possibly be.