### PR TITLE
🌍 #270 Allow seed/size to be passed through in Xunit properties

### DIFF
--- a/src/GalaxyCheck.Xunit/Internal/IPropertyRunner.cs
+++ b/src/GalaxyCheck.Xunit/Internal/IPropertyRunner.cs
@@ -7,7 +7,9 @@ namespace GalaxyCheck.Xunit.Internal
         IGen<Test<object>> Property,
         int Iterations,
         int ShrinkLimit,
-        string? Replay);
+        string? Replay,
+        int? Seed,
+        int? Size);
 
     internal interface IPropertyRunner
     {

--- a/src/GalaxyCheck.Xunit/Internal/PropertyAssertRunner.cs
+++ b/src/GalaxyCheck.Xunit/Internal/PropertyAssertRunner.cs
@@ -9,6 +9,8 @@ namespace GalaxyCheck.Xunit.Internal
         {
             parameters.Property.Select(test => test.Cast<object>()).Assert(
                 replay: parameters.Replay,
+                seed: parameters.Seed,
+                size: parameters.Size,
                 iterations: parameters.Iterations,
                 shrinkLimit: parameters.ShrinkLimit,
                 formatReproduction: (newReplay) => $"{Environment.NewLine}    [Replay(\"{newReplay}\")]",

--- a/src/GalaxyCheck.Xunit/Internal/PropertyInitializer.cs
+++ b/src/GalaxyCheck.Xunit/Internal/PropertyInitializer.cs
@@ -29,10 +29,12 @@ namespace GalaxyCheck.Xunit.Internal
             var replay = testMethodInfo.GetCustomAttributes<ReplayAttribute>().SingleOrDefault()?.Replay;
 
             var propertyRunParameters = new PropertyRunParameters(
-                property,
-                propertyAttribute.Iterations,
-                propertyAttribute.ShrinkLimit,
-                replay);
+                Property: property,
+                Iterations: propertyAttribute.Iterations,
+                ShrinkLimit: propertyAttribute.ShrinkLimit,
+                Replay: replay,
+                Seed: replay == null ? propertyAttribute.NullableSeed : null,
+                Size: replay == null ? propertyAttribute.NullableSize : null);
 
             return new PropertyInitializationResult(
                 propertyAttribute.Runner,

--- a/src/GalaxyCheck.Xunit/Internal/PropertySampleRunner.cs
+++ b/src/GalaxyCheck.Xunit/Internal/PropertySampleRunner.cs
@@ -12,6 +12,8 @@ namespace GalaxyCheck.Xunit.Internal
 
             parameters.Property.Advanced.Print(
                 stdout: log.Add,
+                seed: parameters.Seed,
+                size: parameters.Size,
                 iterations: parameters.Iterations);
 
             throw new SampleException(string.Join(Environment.NewLine, log));

--- a/src/GalaxyCheck.Xunit/PropertyAttribute.cs
+++ b/src/GalaxyCheck.Xunit/PropertyAttribute.cs
@@ -13,6 +13,44 @@ namespace GalaxyCheck
 
         public int Iterations { get; set; } = 100;
 
+        public int Seed
+        {
+            get
+            {
+                if (NullableSeed == null)
+                {
+                    throw new InvalidOperationException($"{nameof(Seed)} was not set, and does not have a default value");
+                }
+
+                throw new InvalidOperationException("");
+            }
+            set
+            {
+                NullableSeed = value;
+            }
+        }
+
+        internal int? NullableSeed { get; private set; }
+
+        public int Size
+        {
+            get
+            {
+                if (NullableSize == null)
+                {
+                    throw new InvalidOperationException($"{nameof(Size)} was not set, and does not have a default value");
+                }
+
+                throw new InvalidOperationException("");
+            }
+            set
+            {
+                NullableSize = value;
+            }
+        }
+
+        internal int? NullableSize { get; private set; }
+
         internal virtual IPropertyRunner Runner => new PropertyAssertRunner();
     }
 }

--- a/tests/GalaxyCheck.Xunit.Tests/IntegrationSample/Tests.cs
+++ b/tests/GalaxyCheck.Xunit.Tests/IntegrationSample/Tests.cs
@@ -1,4 +1,4 @@
-using GalaxyCheck;
+﻿using GalaxyCheck;
 using GalaxyCheck.Gens;
 using GalaxyCheck.Gens.Injection.Int32;
 using Newtonsoft.Json;

--- a/tests/GalaxyCheck.Xunit.Tests/PropertyInitializerTests/AboutSeed.cs
+++ b/tests/GalaxyCheck.Xunit.Tests/PropertyInitializerTests/AboutSeed.cs
@@ -1,0 +1,101 @@
+﻿using FluentAssertions;
+using GalaxyCheck;
+using GalaxyCheck.Xunit.Internal;
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.PropertyInitializerTests
+{
+    public class AboutSeed
+    {
+#pragma warning disable xUnit1000 // Test classes must be public
+        private class Properties
+#pragma warning restore xUnit1000 // Test classes must be public
+        {
+            [Property]
+            public void PropertyWithDefaultSeed()
+            {
+            }
+
+            [Property(Seed = 0)]
+            public void PropertyWithSeed0()
+            {
+            }
+
+            [Property(Seed = 10)]
+            public void PropertyWithSeed10()
+            {
+            }
+
+            [Property(Seed = 10)]
+            [Replay("===asdlasd;lask;lzk;lk")]
+            public void PropertyWithReplayAndSeed()
+            {
+            }
+
+            [Sample]
+            public void SampleWithDefaultSeed()
+            {
+            }
+
+            [Sample(Seed = 0)]
+            public void SampleWithSeed0()
+            {
+            }
+
+            [Sample(Seed = 10)]
+            public void SampleWithSeed10()
+            {
+            }
+
+            [Sample(Seed = 10)]
+            [Replay("===asdlasd;lask;lzk;lk")]
+            public void SampleWithReplayAndSeed()
+            {
+            }
+        }
+
+        [Theory]
+        [InlineData(nameof(Properties.PropertyWithSeed0), 0)]
+        [InlineData(nameof(Properties.PropertyWithSeed10), 10)]
+        [InlineData(nameof(Properties.SampleWithSeed0), 0)]
+        [InlineData(nameof(Properties.SampleWithSeed10), 10)]
+        public void ItPassesThroughSeed(string testMethodName, int expectedSeed)
+        {
+            var testClassType = typeof(Properties);
+            var testMethodInfo = GetMethod(testMethodName);
+
+            var result = PropertyInitializer.Initialize(testClassType, testMethodInfo, new object[] { }, new DefaultPropertyFactory());
+
+            result.Parameters.Seed.Should().Be(expectedSeed);
+        }
+
+        [Theory]
+        [InlineData(nameof(Properties.PropertyWithDefaultSeed))]
+        [InlineData(nameof(Properties.PropertyWithReplayAndSeed))]
+        [InlineData(nameof(Properties.SampleWithDefaultSeed))]
+        [InlineData(nameof(Properties.SampleWithReplayAndSeed))]
+        public void ItDoesNotPassThroughSeed(string testMethodName)
+        {
+            var testClassType = typeof(Properties);
+            var testMethodInfo = GetMethod(testMethodName);
+
+            var result = PropertyInitializer.Initialize(testClassType, testMethodInfo, new object[] { }, new DefaultPropertyFactory());
+
+            result.Parameters.Seed.Should().Be(null);
+        }
+
+        private static MethodInfo GetMethod(string name)
+        {
+            var methodInfo = typeof(Properties).GetMethod(name, BindingFlags.Instance | BindingFlags.Public);
+
+            if (methodInfo == null)
+            {
+                throw new Exception("Unable to locate method");
+            }
+
+            return methodInfo;
+        }
+    }
+}

--- a/tests/GalaxyCheck.Xunit.Tests/PropertyInitializerTests/AboutSize.cs
+++ b/tests/GalaxyCheck.Xunit.Tests/PropertyInitializerTests/AboutSize.cs
@@ -1,0 +1,101 @@
+﻿using FluentAssertions;
+using GalaxyCheck;
+using GalaxyCheck.Xunit.Internal;
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.PropertyInitializerTests
+{
+    public class AboutSize
+    {
+#pragma warning disable xUnit1000 // Test classes must be public
+        private class Properties
+#pragma warning restore xUnit1000 // Test classes must be public
+        {
+            [Property]
+            public void PropertyWithDefaultSize()
+            {
+            }
+
+            [Property(Size = 0)]
+            public void PropertyWithSize0()
+            {
+            }
+
+            [Property(Size = 10)]
+            public void PropertyWithSize10()
+            {
+            }
+
+            [Property(Size = 10)]
+            [Replay("===asdlasd;lask;lzk;lk")]
+            public void PropertyWithReplayAndSize()
+            {
+            }
+
+            [Sample]
+            public void SampleWithDefaultSize()
+            {
+            }
+
+            [Sample(Size = 0)]
+            public void SampleWithSize0()
+            {
+            }
+
+            [Sample(Size = 10)]
+            public void SampleWithSize10()
+            {
+            }
+
+            [Sample(Size = 10)]
+            [Replay("===asdlasd;lask;lzk;lk")]
+            public void SampleWithReplayAndSize()
+            {
+            }
+        }
+
+        [Theory]
+        [InlineData(nameof(Properties.PropertyWithSize0), 0)]
+        [InlineData(nameof(Properties.PropertyWithSize10), 10)]
+        [InlineData(nameof(Properties.SampleWithSize0), 0)]
+        [InlineData(nameof(Properties.SampleWithSize10), 10)]
+        public void ItPassesThroughSize(string testMethodName, int expectedSize)
+        {
+            var testClassType = typeof(Properties);
+            var testMethodInfo = GetMethod(testMethodName);
+
+            var result = PropertyInitializer.Initialize(testClassType, testMethodInfo, new object[] { }, new DefaultPropertyFactory());
+
+            result.Parameters.Size.Should().Be(expectedSize);
+        }
+
+        [Theory]
+        [InlineData(nameof(Properties.PropertyWithDefaultSize))]
+        [InlineData(nameof(Properties.PropertyWithReplayAndSize))]
+        [InlineData(nameof(Properties.SampleWithDefaultSize))]
+        [InlineData(nameof(Properties.SampleWithReplayAndSize))]
+        public void ItDoesNotPassThroughSize(string testMethodName)
+        {
+            var testClassType = typeof(Properties);
+            var testMethodInfo = GetMethod(testMethodName);
+
+            var result = PropertyInitializer.Initialize(testClassType, testMethodInfo, new object[] { }, new DefaultPropertyFactory());
+
+            result.Parameters.Size.Should().Be(null);
+        }
+
+        private static MethodInfo GetMethod(string name)
+        {
+            var methodInfo = typeof(Properties).GetMethod(name, BindingFlags.Instance | BindingFlags.Public);
+
+            if (methodInfo == null)
+            {
+                throw new Exception("Unable to locate method");
+            }
+
+            return methodInfo;
+        }
+    }
+}


### PR DESCRIPTION
Useful for testing, as it allows control of the generators upfront, rather than needing a countexample. Values are ignored if there is an adjacent replay attribute.