### PR TITLE
🌍 #272 Override the StackTrace on assert failure to be of the original exception

### DIFF
--- a/src/GalaxyCheck/Runners/Assert.cs
+++ b/src/GalaxyCheck/Runners/Assert.cs
@@ -52,6 +52,8 @@ namespace GalaxyCheck.Runners
 {
     public class PropertyFailedException : Exception
     {
+        private readonly Counterexample<object?> _counterexample;
+
         public PropertyFailedException(
             Counterexample<object?> counterexample,
             int iterations,
@@ -60,7 +62,10 @@ namespace GalaxyCheck.Runners
             Func<string, string>? formatMessage)
             : base(FormatMessage(formatMessage, BuildMessage(counterexample, iterations, shrinks, formatReproduction)))
         {
+            _counterexample = counterexample;
         }
+
+        public override string StackTrace => _counterexample.Exception?.StackTrace ?? base.StackTrace;
 
         private static string FormatMessage(Func<string, string>? formatMessage, string message) =>
             formatMessage == null


### PR DESCRIPTION
This means that in the test results window, you'll see the exception where it was thrown in your code, rather than where GalaxyCheck threw because the property failed.