### PR TITLE
#169 Protect the inferred maximum count of a from overflowing

### DIFF
--- a/src/GalaxyCheck/Gens/ListGen.cs
+++ b/src/GalaxyCheck/Gens/ListGen.cs
@@ -244,7 +244,7 @@ namespace GalaxyCheck.Gens
             Either<(int minCount, int maxCount), IGen<IReadOnlyList<T>>> FromBounded(int? minCount, int? maxCount)
             {
                 var resolvedMinCount = minCount ?? 0;
-                var resolvedMaxCount = maxCount ?? resolvedMinCount + 20;
+                var resolvedMaxCount = maxCount ?? InferMaxCount(resolvedMinCount);
 
                 if (resolvedMinCount < 0)
                 {
@@ -268,6 +268,21 @@ namespace GalaxyCheck.Gens
                 onUnspecified: () => FromUnspecified(),
                 onExact: count => FromExact(count),
                 onBounded: (minCount, maxCount) => FromBounded(minCount, maxCount));
+        }
+
+        private static int InferMaxCount(int minCount)
+        {
+            try
+            {
+                checked
+                {
+                    return minCount + 20;
+                }
+            }
+            catch (OverflowException)
+            {
+                return int.MaxValue;
+            }
         }
 
         private static IGen<IReadOnlyList<T>> Error(string message) => Gen.Advanced.Error<IReadOnlyList<T>>(nameof(ListGen<T>), message);


### PR DESCRIPTION
When a you provide the list gen a really big minimum, and an unconstrained maximum e.g. `Gen.List().WithCountGreaterThanEqual(int.MaxValue)`, it would previously return the error `Error while running generator ListGen: 'maxCount' cannot be negative`. This is because, if unspecified, we infer the maxCount to be minCount + 20, and we weren't checking for integer overflow.

Now, we set the maxCount to be int.MaxValue if it were to overflow. Out-of-the-box, this will get you a message like:

```
GalaxyCheck.Exceptions+GenErrorException : Error while running generator ListGen: Count limit exceeded. This is a built-in safety mechanism to prevent hanging tests. If generating a list with over 1000 elements was intended, relax this constraint by calling IListGen.DisableCountLimitUnsafe().
```

But at least it's a better hint to what has gone wrong - probably accidentally trying to generate a yuuuuggee list.