### PR TITLE
#276 Add overflow protection for GreaterThan/LessThan byte methods

### DIFF
--- a/src/GalaxyCheck/Gens/Int16Gen.cs
+++ b/src/GalaxyCheck/Gens/Int16Gen.cs
@@ -59,7 +59,7 @@
             {
                 checked
                 {
-                    return gen.GreaterThanEqual((short)(minExclusive + 1)); ;
+                    return gen.GreaterThanEqual((short)(minExclusive + 1));
                 }
             }
             catch (OverflowException ex)

--- a/src/GalaxyCheck/Gens/Int32Gen.cs
+++ b/src/GalaxyCheck/Gens/Int32Gen.cs
@@ -39,7 +39,7 @@
             {
                 checked
                 {
-                    return gen.LessThanEqual((int)(maxExclusive - 1));
+                    return gen.LessThanEqual(maxExclusive - 1);
                 }
             }
             catch (OverflowException ex)
@@ -59,7 +59,7 @@
             {
                 checked
                 {
-                    return gen.GreaterThanEqual((int)(minExclusive + 1)); ;
+                    return gen.GreaterThanEqual(minExclusive + 1);
                 }
             }
             catch (OverflowException ex)

--- a/src/GalaxyCheck/Gens/Int64Gen.cs
+++ b/src/GalaxyCheck/Gens/Int64Gen.cs
@@ -60,7 +60,7 @@
             {
                 checked
                 {
-                    return gen.GreaterThanEqual((long)(minExclusive + 1)); ;
+                    return gen.GreaterThanEqual((long)(minExclusive + 1));
                 }
             }
             catch (OverflowException ex)

--- a/tests/GalaxyCheck.Tests.V2/GenTests/ByteGenTests/AboutExtensions.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenTests/ByteGenTests/AboutExtensions.cs
@@ -1,7 +1,9 @@
-﻿using GalaxyCheck;
+﻿using FluentAssertions;
+using GalaxyCheck;
 using GalaxyCheck.Gens;
 using Moq;
 using NebulaCheck;
+using System;
 using System.Linq;
 using Gen = NebulaCheck.Gen;
 using Property = NebulaCheck.Property;
@@ -38,7 +40,7 @@ namespace Tests.V2.GenTests.ByteGenTests
 
         [Property]
         public NebulaCheck.IGen<Test> GreaterThanDefersToUnderlyingMethod() =>
-            from minExclusive in Gen.Byte()
+            from minExclusive in Gen.Byte().LessThan(byte.MaxValue)
             select Property.ForThese(() =>
             {
                 var mockGen = SetupMock();
@@ -49,8 +51,27 @@ namespace Tests.V2.GenTests.ByteGenTests
             });
 
         [Property]
+        public NebulaCheck.IGen<Test> GreaterThanErrorsAtMaxValue() =>
+            from seed in DomainGen.Seed()
+            from size in DomainGen.Size()
+            select Property.ForThese(() =>
+            {
+                var mockGen = SetupMock();
+
+                var gen = mockGen.Object.GreaterThan(byte.MaxValue);
+
+                mockGen.Verify(gen => gen.GreaterThanEqual(It.IsAny<byte>()), Times.Never);
+
+                Action action = () => gen.SampleOne(seed: seed, size: size);
+
+                action.Should()
+                    .Throw<GalaxyCheck.Exceptions.GenErrorException>()
+                    .WithMessage("Error while running generator Byte().GreaterThan(255): Arithmetic operation resulted in an overflow.");
+            });
+
+        [Property]
         public NebulaCheck.IGen<Test> LessThanDefersToUnderlyingMethod() =>
-            from maxExclusive in Gen.Byte()
+            from maxExclusive in Gen.Byte().GreaterThan(byte.MinValue)
             select Property.ForThese(() =>
             {
                 var mockGen = SetupMock();
@@ -58,6 +79,25 @@ namespace Tests.V2.GenTests.ByteGenTests
                 mockGen.Object.LessThan(maxExclusive);
 
                 mockGen.Verify(gen => gen.LessThanEqual((byte)(maxExclusive - 1)), Times.Once);
+            });
+
+        [Property]
+        public NebulaCheck.IGen<Test> LessThanErrorsAtMinValue() =>
+            from seed in DomainGen.Seed()
+            from size in DomainGen.Size()
+            select Property.ForThese(() =>
+            {
+                var mockGen = SetupMock();
+
+                var gen = mockGen.Object.LessThan(byte.MinValue);
+
+                mockGen.Verify(gen => gen.LessThanEqual(It.IsAny<byte>()), Times.Never);
+
+                Action action = () => gen.SampleOne(seed: seed, size: size);
+
+                action.Should()
+                    .Throw<GalaxyCheck.Exceptions.GenErrorException>()
+                    .WithMessage("Error while running generator Byte().LessThan(0): Arithmetic operation resulted in an overflow.");
             });
 
         private static Mock<IIntGen<byte>> SetupMock()

--- a/tests/GalaxyCheck.Tests.V2/GenTests/ByteGenTests/AboutValidation.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenTests/ByteGenTests/AboutValidation.cs
@@ -25,7 +25,7 @@ namespace Tests.V2.GenTests.ByteGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ByteGen: 'min' cannot be greater than 'max'");
+                    .WithMessage("Error while running generator Byte: 'min' cannot be greater than 'max'");
             });
 
         [Property]
@@ -42,7 +42,7 @@ namespace Tests.V2.GenTests.ByteGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ByteGen: 'origin' must be between 'min' and 'max'");
+                    .WithMessage("Error while running generator Byte: 'origin' must be between 'min' and 'max'");
             });
 
         [Property]
@@ -59,7 +59,7 @@ namespace Tests.V2.GenTests.ByteGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ByteGen: 'origin' must be between 'min' and 'max'");
+                    .WithMessage("Error while running generator Byte: 'origin' must be between 'min' and 'max'");
             });
     }
 }


### PR DESCRIPTION
- Also sneakily fix-up method signature to take byte, rather than int.