### PR TITLE
🌍 #276 Wire up IEnumerable generation to Gen.Create<T>()

### DIFF
--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenBuilder.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenBuilder.cs
@@ -24,7 +24,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers
             {
                 new MemberOverrideReflectedGenHandler(memberOverrides),
                 new RegistryReflectedGenHandler(registeredGensByType, contextualErrorFactory),
-                new ListReflectedGenHandler(),
+                new CollectionReflectedGenHandler(),
                 new SetReflectedGenHandler(),
                 new ArrayReflectedGenHandler(),
                 new EnumReflectedGenHandler(),

--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/CollectionReflectedGenHandler.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/CollectionReflectedGenHandler.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
 {
-    internal class ListReflectedGenHandler : IReflectedGenHandler
+    internal class CollectionReflectedGenHandler : IReflectedGenHandler
     {
         public bool CanHandleGen(Type type, ReflectedGenHandlerContext context)
         {
@@ -27,7 +27,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
             var genericTypeDefinition = type.GetGenericTypeDefinition();
             var methodName = GenMethodByGenericTypeDefinition[genericTypeDefinition];
 
-            var methodInfo = typeof(ListReflectedGenHandler).GetMethod(
+            var methodInfo = typeof(CollectionReflectedGenHandler).GetMethod(
                 methodName,
                 BindingFlags.Static | BindingFlags.NonPublic)!;
 
@@ -42,7 +42,8 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
             { typeof(IReadOnlyList<>), nameof(CreateListGen) },
             { typeof(List<>), nameof(CreateListGen) },
             { typeof(ImmutableList<>), nameof(CreateImmutableListGen) },
-            { typeof(IList<>), nameof(CreateListGen) }
+            { typeof(IList<>), nameof(CreateListGen) },
+            { typeof(IEnumerable<>), nameof(CreateListGen) }
         };
 
         private static IGen<IReadOnlyList<T>> CreateIReadOnlyListGen<T>(IGen<T> elementGen) => elementGen.ListOf();

--- a/tests/GalaxyCheck.Tests.V2/GenTests/ReflectedGenTests/AboutGeneratingCollections.cs
+++ b/tests/GalaxyCheck.Tests.V2/GenTests/ReflectedGenTests/AboutGeneratingCollections.cs
@@ -9,7 +9,7 @@ using Test = NebulaCheck.Test;
 
 namespace Tests.V2.GenTests.ReflectedGenTests
 {
-    public class AboutGeneratingLists
+    public class AboutGeneratingCollections
     {
         [Property]
         public NebulaCheck.IGen<Test> ItCanGenerateLists() =>
@@ -18,7 +18,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
             select Property.ForThese(() =>
             {
                 List<List<int>> SampleTraversal(GalaxyCheck.IGen<List<int>> gen) =>
-                    AboutGeneratingLists.SampleTraversal(gen, seed, size);
+                    AboutGeneratingCollections.SampleTraversal(gen, seed, size);
 
                 var gen0 = GalaxyCheck.Gen.Create<List<int>>();
                 var gen1 = GalaxyCheck.Gen.Int32().ListOf().Select(x => x.ToList());
@@ -36,7 +36,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
             select Property.ForThese(() =>
             {
                 List<IReadOnlyList<int>> SampleTraversal(GalaxyCheck.IGen<IReadOnlyList<int>> gen) =>
-                    AboutGeneratingLists.SampleTraversal(gen, seed, size);
+                    AboutGeneratingCollections.SampleTraversal(gen, seed, size);
 
                 var gen0 = GalaxyCheck.Gen.Create<IReadOnlyList<int>>();
                 var gen1 = GalaxyCheck.Gen.Int32().ListOf();
@@ -54,7 +54,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
             select Property.ForThese(() =>
             {
                 List<ImmutableList<int>> SampleTraversal(GalaxyCheck.IGen<ImmutableList<int>> gen) =>
-                    AboutGeneratingLists.SampleTraversal(gen, seed, size);
+                    AboutGeneratingCollections.SampleTraversal(gen, seed, size);
 
                 var gen0 = GalaxyCheck.Gen.Create<ImmutableList<int>>();
                 var gen1 = GalaxyCheck.Gen.Int32().ListOf().Select(x => x.ToImmutableList());
@@ -72,7 +72,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
             select Property.ForThese(() =>
             {
                 List<IList<int>> SampleTraversal(GalaxyCheck.IGen<IList<int>> gen) =>
-                    AboutGeneratingLists.SampleTraversal(gen, seed, size);
+                    AboutGeneratingCollections.SampleTraversal(gen, seed, size);
 
                 var gen0 = GalaxyCheck.Gen.Create<IList<int>>();
                 var gen1 = GalaxyCheck.Gen.Int32().ListOf().Select(x => x.ToList());
@@ -90,9 +90,27 @@ namespace Tests.V2.GenTests.ReflectedGenTests
             select Property.ForThese(() =>
             {
                 List<IReadOnlyCollection<int>> SampleTraversal(GalaxyCheck.IGen<IReadOnlyCollection<int>> gen) =>
-                    AboutGeneratingLists.SampleTraversal(gen, seed, size);
+                    AboutGeneratingCollections.SampleTraversal(gen, seed, size);
 
                 var gen0 = GalaxyCheck.Gen.Create<IReadOnlyCollection<int>>();
+                var gen1 = GalaxyCheck.Gen.Int32().ListOf();
+
+                var sample0 = SampleTraversal(gen0);
+                var sample1 = SampleTraversal(gen1);
+
+                sample0.Should().BeEquivalentTo(sample1);
+            });
+
+        [Property]
+        public NebulaCheck.IGen<Test> ItCanGenerateIEnumerables() =>
+            from seed in DomainGen.Seed()
+            from size in DomainGen.Size()
+            select Property.ForThese(() =>
+            {
+                List<IEnumerable<int>> SampleTraversal(GalaxyCheck.IGen<IEnumerable<int>> gen) =>
+                    AboutGeneratingCollections.SampleTraversal(gen, seed, size);
+
+                var gen0 = GalaxyCheck.Gen.Create<IEnumerable<int>>();
                 var gen1 = GalaxyCheck.Gen.Int32().ListOf();
 
                 var sample0 = SampleTraversal(gen0);
@@ -113,7 +131,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
             select Property.ForThese(() =>
             {
                 List<List<ClassWithOneProperty>> SampleTraversal(GalaxyCheck.IGen<List<ClassWithOneProperty>> gen) =>
-                    AboutGeneratingLists.SampleTraversal(gen, seed, size);
+                    AboutGeneratingCollections.SampleTraversal(gen, seed, size);
 
                 var gen0 = GalaxyCheck.Gen.Create<List<ClassWithOneProperty>>();
                 var gen1 = GalaxyCheck.Gen.Create<ClassWithOneProperty>().ListOf().Select(x => x.ToList());
@@ -133,7 +151,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
             select Property.ForThese(() =>
             {
                 List<List<RecordWithOneProperty>> SampleTraversal(GalaxyCheck.IGen<List<RecordWithOneProperty>> gen) =>
-                    AboutGeneratingLists.SampleTraversal(gen, seed, size);
+                    AboutGeneratingCollections.SampleTraversal(gen, seed, size);
 
                 var gen0 = GalaxyCheck.Gen.Create<List<RecordWithOneProperty>>();
                 var gen1 = GalaxyCheck.Gen.Create<RecordWithOneProperty>().ListOf().Select(x => x.ToList());


### PR DESCRIPTION
Generating lists is good enough for now. This should be configured later to generate infinite IEnumerables, as Gen.Infinite supports (but perhaps behind a configuration flag).