### PR TITLE
🌍 #287 Property.Precondition exhausts when given an unfeasible predicate, rather than hanging forever

### DIFF
--- a/src/GalaxyCheck/Internal/EnumerableExtensions.cs
+++ b/src/GalaxyCheck/Internal/EnumerableExtensions.cs
@@ -144,6 +144,8 @@ namespace GalaxyCheck.Internal
             {
                 if (isCounted(element) == false)
                 {
+                    // The element is considered neither a discard or a non-discard, don't increment or reset the
+                    // consecutive discard count.
                     return consecutiveDiscardCount;
                 }
 

--- a/src/GalaxyCheck/Runners/Check.cs
+++ b/src/GalaxyCheck/Runners/Check.cs
@@ -77,11 +77,15 @@ namespace GalaxyCheck
         }
 
         private static IEnumerable<AbstractTransition<T>> UnfoldTransitions<T>(AbstractTransition<T> initialTransition) =>
-            EnumerableExtensions.Unfold(
-                initialTransition,
-                previousTransition => previousTransition is Termination<T>
-                    ? new Option.None<AbstractTransition<T>>()
-                    : new Option.Some<AbstractTransition<T>>(previousTransition.NextTransition()));
+            EnumerableExtensions
+                .Unfold(
+                    initialTransition,
+                    previousTransition => previousTransition is Termination<T>
+                        ? new Option.None<AbstractTransition<T>>()
+                        : new Option.Some<AbstractTransition<T>>(previousTransition.NextTransition()))
+                .WithDiscardCircuitBreaker(
+                    transition => transition is InstanceCompleteTransition<T>,
+                    transition => ((InstanceCompleteTransition<T>)transition).WasDiscard);
 
         private record TransitionAggregation<T>(
             ImmutableList<CheckIteration<T>> Checks,

--- a/src/GalaxyCheck/Runners/CheckAutomata/InstanceCompleteTransition.cs
+++ b/src/GalaxyCheck/Runners/CheckAutomata/InstanceCompleteTransition.cs
@@ -24,7 +24,6 @@ namespace GalaxyCheck.Runners.CheckAutomata
         {
             var nextSize = Resize(state, null, instance);
             // TODO: Resize on discards more like Gen.Where does
-            // TODO: Exhaustion protection
             return new InitialTransition<T>(state
                 .IncrementDiscards()
                 .WithNextGenParameters(instance.NextParameters.With(size: nextSize)));

--- a/tests/GalaxyCheck.Tests.V2/RunnerTests/CheckTests/AboutExhaustion.cs
+++ b/tests/GalaxyCheck.Tests.V2/RunnerTests/CheckTests/AboutExhaustion.cs
@@ -10,9 +10,19 @@ namespace Tests.V2.RunnerTests.CheckTests
     public class AboutExhaustion
     {
         [Property(Iterations = 1)]
-        public void ItCanExhaust([Seed] int seed, [Size] int size)
+        public void ItExhaustsWhenGenerationIsImpossible([Seed] int seed, [Size] int size)
         {
             var property = GalaxyCheck.Gen.Int32().Where(x => false).ForAll(_ => true);
+
+            Action test = () => property.Check(seed: seed, size: size, deepCheck: false);
+
+            test.Should().Throw<GalaxyCheck.Exceptions.GenExhaustionException>();
+        }
+
+        [Property(Iterations = 1)]
+        public void ItExhaustsWhenPreconditionIsImpossible([Seed] int seed, [Size] int size)
+        {
+            var property = GalaxyCheck.Gen.Int32().ForAll(_ => GalaxyCheck.Property.Precondition(false));
 
             Action test = () => property.Check(seed: seed, size: size, deepCheck: false);
 


### PR DESCRIPTION
Like `Gen.Int32().GreaterThan(0).Where(x => x < 0)` might exhaust, "late filters" via `Property.Precondition` now exhaust when given an unfeasible predicate. For example:

```csharp
[Property]
public void MyProperty([GreaterThan(0)] int x)
{
    Property.Precondition(x < 0);
}
```

Will fail quickly, rather than hanging forever.