### PR TITLE
🌍 #289 Fix a couple of bugs manifesting in Property.Precondition

### DIFF
--- a/src/GalaxyCheck.Xunit/Internal/DefaultPropertyFactory.cs
+++ b/src/GalaxyCheck.Xunit/Internal/DefaultPropertyFactory.cs
@@ -12,7 +12,6 @@ namespace GalaxyCheck.Xunit.Internal
             IGenFactory? genFactory,
             IReadOnlyDictionary<int, IGen> customGens)
         {
-
             return Property.Reflect(methodInfo, target, genFactory, customGens);
         }
     }

--- a/src/GalaxyCheck/Gens/Parameters/GenParameters.cs
+++ b/src/GalaxyCheck/Gens/Parameters/GenParameters.cs
@@ -36,5 +36,10 @@
             IRng? rng = null,
             Size? size = null) =>
                 new GenParameters(rng ?? Rng, size ?? Size);
+
+        public override string ToString()
+        {
+            return $"Rng={Rng},Size={Size}";
+        }
     }
 }

--- a/src/GalaxyCheck/Gens/Parameters/Internal/Rng.cs
+++ b/src/GalaxyCheck/Gens/Parameters/Internal/Rng.cs
@@ -44,5 +44,10 @@ namespace GalaxyCheck.Gens.Parameters.Internal
 
             return Random.NextLong(min, maxOffset);
         }
+
+        public override string ToString()
+        {
+            return "[" + string.Join(",", new [] { Family, Seed, Order }) + "]";
+        }
     }
 }

--- a/src/GalaxyCheck/Gens/Parameters/Size.cs
+++ b/src/GalaxyCheck/Gens/Parameters/Size.cs
@@ -19,5 +19,10 @@ namespace GalaxyCheck.Gens.Parameters
         public Size Increment() => new Size((Value + 1) % 100);
 
         public Size BigIncrement() => new Size((Value + 5) % 100);
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
     }
 }

--- a/src/GalaxyCheck/Runners/Check/Automata/CheckStateContext.cs
+++ b/src/GalaxyCheck/Runners/Check/Automata/CheckStateContext.cs
@@ -77,12 +77,10 @@ namespace GalaxyCheck.Runners.Check.Automata
             .ThenByDescending(c => c.ReplayParameters.Size.Value) // Bigger sizes are more likely to normalize
             .FirstOrDefault();
 
-        public CheckStateContext<T> IncrementCompletedIterations() => this with
+        public CheckStateContext<T> IncrementCompletedIterations() => (this with
         {
             CompletedIterations = CompletedIterations + 1,
-            ConsecutiveDiscards = 0,
-            ConsecutiveLateDiscards = 0
-        };
+        }).ResetConsecutiveDiscards();
 
         public CheckStateContext<T> IncrementDiscards(bool wasLateDiscard) => this with
         {
@@ -96,8 +94,9 @@ namespace GalaxyCheck.Runners.Check.Automata
             Shrinks = Shrinks + 1
         };
 
-        public CheckStateContext<T> ResetConsecutiveLateDiscards() => this with
+        public CheckStateContext<T> ResetConsecutiveDiscards() => this with
         {
+            ConsecutiveDiscards = 0,
             ConsecutiveLateDiscards = 0
         };
 

--- a/src/GalaxyCheck/Runners/Check/Automata/GenerationStates.cs
+++ b/src/GalaxyCheck/Runners/Check/Automata/GenerationStates.cs
@@ -76,14 +76,19 @@ namespace GalaxyCheck.Runners.Check.Automata
             bool WasReplay) : CheckState<T>
         {
             public CheckStateTransition<T> Transition(CheckStateContext<T> context) => WasDiscard == true
-                ? TransitionFromDiscard(context, WasLateDiscard)
+                ? TransitionFromDiscard(context, Instance, WasLateDiscard)
                 : CounterexampleContext == null
                     ? NextStateWithoutCounterexample(context, Instance)
                     : NextStateWithCounterexample(context, Instance, CounterexampleContext, WasReplay);
 
-            private static CheckStateTransition<T> TransitionFromDiscard(CheckStateContext<T> context, bool wasLateDiscard) => new CheckStateTransition<T>(
-                new Generation_Begin<T>(),
-                context.IncrementDiscards(wasLateDiscard));
+            private static CheckStateTransition<T> TransitionFromDiscard(
+                CheckStateContext<T> context,
+                IGenInstance<Test<T>> instance,
+                bool wasLateDiscard) => new CheckStateTransition<T>(
+                    new Generation_Begin<T>(),
+                    context
+                        .WithNextGenParameters(instance.NextParameters)
+                        .IncrementDiscards(wasLateDiscard));
 
             private static CheckStateTransition<T> NextStateWithoutCounterexample(
                 CheckStateContext<T> context,

--- a/src/GalaxyCheck/Runners/Check/Sizing/ResizeCheckStateTransitionDecorator.cs
+++ b/src/GalaxyCheck/Runners/Check/Sizing/ResizeCheckStateTransitionDecorator.cs
@@ -30,11 +30,21 @@ namespace GalaxyCheck.Runners.Check.Sizing
             GenerationStates.Generation_End<T> generationEndState,
             CheckStateContext<T> nextContext)
         {
-            if (nextContext.ConsecutiveLateDiscards >= MaxConsecutiveDiscards)
+            if (generationEndState.WasLateDiscard)
             {
-                return nextContext
-                    .WithNextGenParameters(nextContext.NextParameters with { Size = nextContext.NextParameters.Size.BigIncrement() })
-                    .ResetConsecutiveLateDiscards();
+                if (nextContext.ConsecutiveLateDiscards >= MaxConsecutiveDiscards)
+                {
+                    return nextContext
+                        .WithNextGenParameters(nextContext.NextParameters with
+                        {
+                            Size = nextContext.NextParameters.Size.BigIncrement()
+                        })
+                        .ResetConsecutiveDiscards();
+                }
+                else
+                {
+                    return nextContext;
+                }
             }
             else
             {


### PR DESCRIPTION
- Ensure we use the next parameters recommended by the generator after a discard. This doesn't matter when the discard was caused by a generator, as it will pass itself the correct next parameters internally, but it manifests as using the same seed when it's a late discard.