### PR TITLE
🌍 #318 Count all iterations after the initial counterexample as shrinks

### DIFF
--- a/src/GalaxyCheck.Tests/RunnerTests/AssertTests/__snapshots__/Snapshots.Snapshot_AssertFailure_IntLessThanEquals.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/AssertTests/__snapshots__/Snapshots.Snapshot_AssertFailure_IntLessThanEquals.snap
@@ -1,4 +1,4 @@
-﻿Falsified after 65 tests (76 shrinks)
+﻿Falsified after 60 tests (81 shrinks)
 Reproduction: H4sIAAAAAAAACjM0MjYxM7QwMDLTMzfSM7TCD02sjIDQAAATzJbgNQAAAA==
 Counterexample: 1000
 

--- a/src/GalaxyCheck/Runners/Check.cs
+++ b/src/GalaxyCheck/Runners/Check.cs
@@ -50,9 +50,9 @@ namespace GalaxyCheck
             var transitionAggregation = AggregateTransitions(transitions);
 
             return new CheckResult<T>(
-                transitionAggregation.FinalContext.CompletedIterations,
+                transitionAggregation.FinalContext.CompletedIterationsUntilCounterexample,
                 transitionAggregation.FinalContext.Discards,
-                transitionAggregation.FinalContext.Shrinks,
+                transitionAggregation.FinalContext.Shrinks + transitionAggregation.FinalContext.CompletedIterationsAfterCounterexample,
                 transitionAggregation.FinalContext.Counterexample == null
                     ? null
                     : FromCounterexampleContext(transitionAggregation.FinalContext.Counterexample),

--- a/src/GalaxyCheck/Runners/Check/Automata/CheckStateContext.cs
+++ b/src/GalaxyCheck/Runners/Check/Automata/CheckStateContext.cs
@@ -1,5 +1,4 @@
-﻿using GalaxyCheck.Gens.Iterations.Generic;
-using GalaxyCheck.Gens.Parameters;
+﻿using GalaxyCheck.Gens.Parameters;
 using GalaxyCheck.ExampleSpaces;
 using System;
 using System.Collections.Generic;
@@ -16,7 +15,11 @@ namespace GalaxyCheck.Runners.Check.Automata
 
         public int ShrinkLimit { get; private init; }
 
-        public int CompletedIterations { get; private init; }
+        public int CompletedIterationsUntilCounterexample { get; private init; }
+
+        public int CompletedIterationsAfterCounterexample { get; private init; }
+
+        public int CompletedIterations => CompletedIterationsUntilCounterexample + CompletedIterationsAfterCounterexample;
 
         public int Discards { get; private init; }
 
@@ -36,7 +39,8 @@ namespace GalaxyCheck.Runners.Check.Automata
             IGen<Test<T>> property,
             int requestedIterations,
             int shrinkLimit,
-            int completedIterations,
+            int completedIterationsUntilCounterexample,
+            int completedIterationsAfterCounterexample,
             int discards,
             int shrinks,
             ImmutableList<CounterexampleContext<T>> counterexampleContextHistory,
@@ -46,7 +50,8 @@ namespace GalaxyCheck.Runners.Check.Automata
             Property = property;
             RequestedIterations = requestedIterations;
             ShrinkLimit = shrinkLimit;
-            CompletedIterations = completedIterations;
+            CompletedIterationsUntilCounterexample = completedIterationsUntilCounterexample;
+            CompletedIterationsAfterCounterexample = completedIterationsAfterCounterexample;
             Discards = discards;
             Shrinks = shrinks;
             CounterexampleContextHistory = counterexampleContextHistory;
@@ -66,6 +71,7 @@ namespace GalaxyCheck.Runners.Check.Automata
                 0,
                 0,
                 0,
+                0,
                 ImmutableList.Create<CounterexampleContext<T>>(),
                 initialParameters,
                 deepCheck)
@@ -79,7 +85,12 @@ namespace GalaxyCheck.Runners.Check.Automata
 
         public CheckStateContext<T> IncrementCompletedIterations() => (this with
         {
-            CompletedIterations = CompletedIterations + 1,
+            CompletedIterationsUntilCounterexample = Counterexample == null
+                ? CompletedIterationsUntilCounterexample + 1
+                : CompletedIterationsUntilCounterexample,
+            CompletedIterationsAfterCounterexample = Counterexample == null
+                ? CompletedIterationsAfterCounterexample
+                : CompletedIterationsAfterCounterexample + 1,
         }).ResetConsecutiveDiscards();
 
         public CheckStateContext<T> IncrementDiscards(bool wasLateDiscard) => this with


### PR DESCRIPTION
It's more interesting to see how many tests it took until the original failure. Otherwise, the deep shrink mechanism might take you to 100 iterations. And if we see "100 tests", it might give the false impression that the test only JUST failed.