### PR TITLE
🌍 Update .NET version to 6.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Restore dependencies
         run: dotnet restore GalaxyCheck.sln
       - name: Build
@@ -48,7 +48,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Make NebulaCheck
         run: |
           ls
@@ -92,7 +92,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Download
         uses: actions/download-artifact@v1
         with:
@@ -113,7 +113,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Restore
         run: |
           for project in $PACKABLE_PROJECTS; do
@@ -158,7 +158,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Download
         uses: actions/download-artifact@v1
         with:

--- a/src/GalaxyCheck.Benchmarks/GalaxyCheck.Benchmarks.csproj
+++ b/src/GalaxyCheck.Benchmarks/GalaxyCheck.Benchmarks.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GalaxyCheck.Benchmarks/RngBenchmark.cs
+++ b/src/GalaxyCheck.Benchmarks/RngBenchmark.cs
@@ -20,12 +20,12 @@ namespace GalaxyCheck.Benchmarks
         [Arguments(0, 100)]
         [Arguments(0, 1000)]
         [Arguments(long.MinValue, long.MaxValue)]
-        public void RandomLong(long MinValue, long MaxValue)
+        public void RandomLong(long minValue, long maxValue)
         {
             for (var seed = _seed; seed < (_seed + OperationsPerInvoke); seed++)
             {
                 var rng = Rng.Create(seed);
-                rng.Value(MinValue, MaxValue);
+                rng.Value(minValue, maxValue);
             }
         }
     }

--- a/src/GalaxyCheck.Sandbox/GalaxyCheck.Sandbox.csproj
+++ b/src/GalaxyCheck.Sandbox/GalaxyCheck.Sandbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/GalaxyCheck.Tests/GalaxyCheck.Tests.csproj
+++ b/src/GalaxyCheck.Tests/GalaxyCheck.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
     <RootNamespace>Tests.V2</RootNamespace>
@@ -10,17 +10,17 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="NebulaCheck" Version="0.0.0-1565955127" />
     <PackageReference Include="NebulaCheck.Xunit" Version="0.0.0-1565955127" />
     <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/GalaxyCheck.Xunit.CodeAnalysis.Tests/Analyzers/Verifier.cs
+++ b/src/GalaxyCheck.Xunit.CodeAnalysis.Tests/Analyzers/Verifier.cs
@@ -21,7 +21,10 @@ namespace GalaxyCheck.Xunit.CodeAnalysis.Tests.Analyzers
             string[] sources,
             params DiagnosticResult[] diagnostics)
         {
-            var test = new CSharpCodeFixTest<TAnalyzer, EmptyCodeFixProvider, XUnitVerifier>();
+            var test = new CSharpCodeFixTest<TAnalyzer, EmptyCodeFixProvider, XUnitVerifier>()
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            };
 
             foreach (var source in sources)
                 test.TestState.Sources.Add(source);

--- a/src/GalaxyCheck.Xunit.CodeAnalysis.Tests/CodeRefactoringProviders/Verifier.cs
+++ b/src/GalaxyCheck.Xunit.CodeAnalysis.Tests/CodeRefactoringProviders/Verifier.cs
@@ -4,7 +4,6 @@ using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.Text;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
@@ -14,20 +13,6 @@ namespace GalaxyCheck.Xunit.CodeAnalysis.Tests.CodeRefactoringProviders
     public static class Verifier<TCodeRefactoringProvider>
         where TCodeRefactoringProvider : CodeRefactoringProvider, new()
     {
-        public static Task Verify(
-            string code,
-            string codeProvidingRefactor,
-            string expectedRefactoredCode,
-            string expectedRefactoringTitle)
-        {
-            var linePosition = new LinePosition(1, 1);
-
-            var indexOfCodeRefactoringProvider = code.IndexOf(codeProvidingRefactor);
-
-
-            return Verify(code, linePosition, expectedRefactoredCode, expectedRefactoringTitle);
-        }
-
         public static async Task Verify(
             string code,
             LinePosition codeProvidingRefactorPosition,
@@ -42,7 +27,8 @@ namespace GalaxyCheck.Xunit.CodeAnalysis.Tests.CodeRefactoringProviders
                 CodeActionVerifier = (codeAction, verifier) =>
                 {
                     verifier.Equal(codeAction.Title, expectedRefactoringTitle);
-                }
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60
             };
 
             test.ExpectedDiagnostics.Add(new DiagnosticResult("Refactoring", DiagnosticSeverity.Hidden)
@@ -71,7 +57,8 @@ namespace GalaxyCheck.Xunit.CodeAnalysis.Tests.CodeRefactoringProviders
                 CodeActionVerifier = (codeAction, verifier) =>
                 {
                     verifier.Fail("Expected code not to be refactored");
-                }
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60
             };
 
             test.ExpectedDiagnostics.Add(new DiagnosticResult("Refactoring", DiagnosticSeverity.Hidden)

--- a/src/GalaxyCheck.Xunit.CodeAnalysis.Tests/GalaxyCheck.Xunit.CodeAnalysis.Tests.csproj
+++ b/src/GalaxyCheck.Xunit.CodeAnalysis.Tests/GalaxyCheck.Xunit.CodeAnalysis.Tests.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/GalaxyCheck.Xunit.CodeAnalysis/GalaxyCheck.Xunit.CodeAnalysis.csproj
+++ b/src/GalaxyCheck.Xunit.CodeAnalysis/GalaxyCheck.Xunit.CodeAnalysis.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NuspecFile>GalaxyCheck.Xunit.CodeAnalysis.nuspec</NuspecFile>
     <NuspecProperties>PackageVersion=$(PackageVersion)</NuspecProperties>
     <NuspecBasePath></NuspecBasePath>
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/GalaxyCheck.Xunit.CodeAnalysis/GalaxyCheck.Xunit.CodeAnalysis.nuspec
+++ b/src/GalaxyCheck.Xunit.CodeAnalysis/GalaxyCheck.Xunit.CodeAnalysis.nuspec
@@ -11,8 +11,8 @@
     <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
-    <file src="bin\Release\netstandard2.0\GalaxyCheck.Xunit.CodeAnalysis.pdb" target="lib" />
-    <file src="bin\Release\netstandard2.0\*.dll" target="analyzers\dotnet\cs" exclude="**\Microsoft.CodeAnalysis.*;**\System.Collections.Immutable.*;**\System.Reflection.Metadata.*;**\System.Composition.*" />
+    <file src="bin\Release\net6.0\GalaxyCheck.Xunit.CodeAnalysis.pdb" target="lib" />
+    <file src="bin\Release\net6.0\*.dll" target="analyzers\dotnet\cs" exclude="**\Microsoft.CodeAnalysis.*;**\System.Collections.Immutable.*;**\System.Reflection.Metadata.*;**\System.Composition.*" />
     <file src="tools\*.ps1" target="tools\" />
   </files>
 </package>

--- a/src/GalaxyCheck.Xunit.Tests/GalaxyCheck.Xunit.Tests.csproj
+++ b/src/GalaxyCheck.Xunit.Tests/GalaxyCheck.Xunit.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
     <RootNamespace>Tests</RootNamespace>
@@ -16,14 +16,14 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/GalaxyCheck.Xunit.Tests/IntegrationSample/IntegrationSample.csproj
+++ b/src/GalaxyCheck.Xunit.Tests/IntegrationSample/IntegrationSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>

--- a/src/GalaxyCheck.Xunit/GalaxyCheck.Xunit.csproj
+++ b/src/GalaxyCheck.Xunit/GalaxyCheck.Xunit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile Condition="'$(Configuration)' == 'Release'">true</GenerateDocumentationFile>

--- a/src/GalaxyCheck.Xunit/GalaxyCheck.Xunit.nuspec
+++ b/src/GalaxyCheck.Xunit/GalaxyCheck.Xunit.nuspec
@@ -17,8 +17,8 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="bin\Release\netstandard2.0\GalaxyCheck.Xunit.dll" target="lib\netstandard2.0" />
-        <file src="bin\Release\netstandard2.0\GalaxyCheck.Xunit.xml" target="lib\netstandard2.0" />
-        <file src="bin\Release\netstandard2.0\GalaxyCheck.Xunit.pdb" target="lib\netstandard2.0" />
+        <file src="bin\Release\net6.0\GalaxyCheck.Xunit.dll" target="lib\net6.0" />
+        <file src="bin\Release\net6.0\GalaxyCheck.Xunit.xml" target="lib\net6.0" />
+        <file src="bin\Release\net6.0\GalaxyCheck.Xunit.pdb" target="lib\net6.0" />
     </files>
 </package>

--- a/src/GalaxyCheck.Xunit/Internal/PropertyInitializer.cs
+++ b/src/GalaxyCheck.Xunit/Internal/PropertyInitializer.cs
@@ -22,7 +22,7 @@ namespace GalaxyCheck.Xunit.Internal
             object[] constructorArguments,
             IPropertyFactory propertyFactory)
         {
-            var testClassInstance = Activator.CreateInstance(testClassType, constructorArguments);
+            var testClassInstance = Activator.CreateInstance(testClassType, constructorArguments)!;
             var propertyAttribute = testMethodInfo.GetCustomAttributes<PropertyAttribute>(inherit: true).Single();
 
             var genFactory = TryResolveGenFactory(testClassType, testMethodInfo);
@@ -75,13 +75,13 @@ namespace GalaxyCheck.Xunit.Internal
             var property = target.GetType().GetProperty(memberName, bindingFlags);
             if (property != null)
             {
-                return CastToGen(property.GetValue(target), memberName);
+                return CastToGen(property.GetValue(target)!, memberName);
             }
 
             var field = target.GetType().GetField(memberName, bindingFlags);
             if (field != null)
             {
-                return CastToGen(field.GetValue(target), memberName);
+                return CastToGen(field.GetValue(target)!, memberName);
             }
 
             return Gen.Constant<object?>(null);

--- a/src/GalaxyCheck/GalaxyCheck.csproj
+++ b/src/GalaxyCheck/GalaxyCheck.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AppDesignerFolder>(none)</AppDesignerFolder>
@@ -14,10 +14,4 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/nth-commit/GalaxyCheck</RepositoryUrl>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-  </ItemGroup>
-
 </Project>

--- a/src/GalaxyCheck/Gens/ErrorGen.cs
+++ b/src/GalaxyCheck/Gens/ErrorGen.cs
@@ -23,10 +23,10 @@
             internal static IGen Error(Type type, string genName, string message)
             {
                 var genericErrorGen = typeof(Advanced)
-                    .GetMethod(nameof(Advanced.Error))
+                    .GetMethod(nameof(Advanced.Error))!
                     .MakeGenericMethod(type);
 
-                return (IGen)genericErrorGen.Invoke(null, new object?[] { genName, message });
+                return (IGen)genericErrorGen.Invoke(null, new object?[] { genName, message })!;
             }
         }
     }

--- a/src/GalaxyCheck/Gens/ParametersGen.cs
+++ b/src/GalaxyCheck/Gens/ParametersGen.cs
@@ -80,10 +80,10 @@ namespace GalaxyCheck.Gens
                 var configuredGenFactory = ConfigureGenFactory(genFactory, parameterInfo);
 
                 var createGenMethodInfo = typeof(IGenFactory)
-                    .GetMethod(nameof(IGenFactory.Create))
+                    .GetMethod(nameof(IGenFactory.Create))!
                     .MakeGenericMethod(parameterInfo.ParameterType);
 
-                var gen = (IGen)createGenMethodInfo.Invoke(configuredGenFactory, new object[] { });
+                var gen = (IGen)createGenMethodInfo.Invoke(configuredGenFactory, new object[] { })!;
 
                 return gen
                     .Cast<object>()

--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/ArrayReflectedGenHandler.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/ArrayReflectedGenHandler.cs
@@ -10,7 +10,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
 
         public IGen CreateGen(IReflectedGenHandler innerHandler, Type type, ReflectedGenHandlerContext context)
         {
-            var elementType = type.GetElementType();
+            var elementType = type.GetElementType()!;
             var elementGen = innerHandler.CreateGen(elementType, context);
 
             var methodInfo = typeof(ArrayReflectedGenHandler).GetMethod(
@@ -19,7 +19,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
 
             var genericMethodInfo = methodInfo.MakeGenericMethod(elementType);
 
-            return (IGen)genericMethodInfo.Invoke(null!, new object[] { elementGen });
+            return (IGen)genericMethodInfo.Invoke(null!, new object[] { elementGen })!;
         }
 
         private static IGen<T[]> CreateArrayGen<T>(IGen<T> elementGen) => elementGen.ListOf().Select(x => x.ToArray());

--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/CollectionReflectedGenHandler.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/CollectionReflectedGenHandler.cs
@@ -33,7 +33,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
 
             var genericMethodInfo = methodInfo.MakeGenericMethod(elementType);
 
-            return (IGen)genericMethodInfo.Invoke(null!, new object[] { elementGen });
+            return (IGen)genericMethodInfo.Invoke(null!, new object[] { elementGen })!;
         }
 
         private static readonly IReadOnlyDictionary<Type, string> GenMethodByGenericTypeDefinition = new Dictionary<Type, string>

--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/DefaultConstructorReflectedGenHandler.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/DefaultConstructorReflectedGenHandler.cs
@@ -25,7 +25,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
 
             var genericMethodInfo = methodInfo.MakeGenericMethod(type);
 
-            return (IGen)genericMethodInfo.Invoke(null!, new object[] { innerHandler, context, _errorFactory });
+            return (IGen)genericMethodInfo.Invoke(null!, new object[] { innerHandler, context, _errorFactory })!;
         }
 
         private static IGen<T> CreateGenGeneric<T>(IReflectedGenHandler innerHandler, ReflectedGenHandlerContext context, ContextualErrorFactory errorFactory)
@@ -39,12 +39,12 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
                     T instance;
                     try
                     {
-                        instance = (T)Activator.CreateInstance(typeof(T));
+                        instance = (T)Activator.CreateInstance(typeof(T))!;
                     }
                     catch (TargetInvocationException ex)
                     {
                         var innerEx = ex.InnerException;
-                        var message = $"'{innerEx.GetType()}' was thrown while calling constructor with message '{innerEx.Message}'";
+                        var message = $"'{innerEx!.GetType()}' was thrown while calling constructor with message '{innerEx.Message}'";
                         return errorFactory(message, context).Cast<T>();
                     }
 
@@ -57,7 +57,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
                         catch (TargetInvocationException ex)
                         {
                             var innerEx = ex.InnerException;
-                            var message = $"'{innerEx.GetType()}' was thrown while setting property with message '{innerEx.Message}'";
+                            var message = $"'{innerEx!.GetType()}' was thrown while setting property with message '{innerEx.Message}'";
                             return errorFactory(message, context).Cast<T>();
                         }
                     }

--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/EnumReflectedGenHandler.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/EnumReflectedGenHandler.cs
@@ -9,9 +9,9 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
 
         public IGen CreateGen(IReflectedGenHandler innerHandler, Type type, ReflectedGenHandlerContext context)
         {
-            var genMethodInfo = typeof(Gen).GetMethod(nameof(Gen.Enum), BindingFlags.Public | BindingFlags.Static);
+            var genMethodInfo = typeof(Gen).GetMethod(nameof(Gen.Enum), BindingFlags.Public | BindingFlags.Static)!;
             var genericGenMethodInfo = genMethodInfo.MakeGenericMethod(type);
-            return (IGen)genericGenMethodInfo.Invoke(null!, new object[] { });
+            return (IGen)genericGenMethodInfo.Invoke(null!, new object[] { })!;
         }
     }
 }

--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/NonDefaultConstructorReflectedGenHandler.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/NonDefaultConstructorReflectedGenHandler.cs
@@ -24,7 +24,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
 
             var genericMethodInfo = methodInfo.MakeGenericMethod(type);
 
-            return (IGen)genericMethodInfo.Invoke(null!, new object[] { innerHandler, context, _errorFactory });
+            return (IGen)genericMethodInfo.Invoke(null!, new object[] { innerHandler, context, _errorFactory })!;
         }
 
         private static IGen<T> CreateGenGeneric<T>(IReflectedGenHandler innerHandler, ReflectedGenHandlerContext context, ContextualErrorFactory errorFactory)
@@ -34,7 +34,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
             var parameterGens = constructor
                 .GetParameters()
                 .Select(parameter => innerHandler
-                    .CreateGen(parameter.ParameterType, context.Next(parameter.Name, parameter.ParameterType)) // TODO: Indicate it's a ctor param in the path
+                    .CreateGen(parameter.ParameterType, context.Next(parameter.Name ?? "<unknown>", parameter.ParameterType)) // TODO: Indicate it's a ctor param in the path
                     .Cast<object>());
 
             return Gen
@@ -48,7 +48,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
                     catch (TargetInvocationException ex)
                     {
                         var innerEx = ex.InnerException;
-                        var message = $"'{innerEx.GetType()}' was thrown while calling constructor with message '{innerEx.Message}'";
+                        var message = $"'{innerEx!.GetType()}' was thrown while calling constructor with message '{innerEx.Message}'";
                         return errorFactory(message, context).Cast<T>();
                     }
                 });

--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/SetReflectedGenHandler.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/SetReflectedGenHandler.cs
@@ -33,7 +33,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
 
             var genericMethodInfo = methodInfo.MakeGenericMethod(elementType);
 
-            return (IGen)genericMethodInfo.Invoke(null!, new object[] { elementGen });
+            return (IGen)genericMethodInfo.Invoke(null!, new object[] { elementGen })!;
         }
 
         private static readonly IReadOnlyDictionary<Type, string> GenMethodByGenericTypeDefinition = new Dictionary<Type, string>

--- a/src/GalaxyCheck/Internal/GenExtensions.cs
+++ b/src/GalaxyCheck/Internal/GenExtensions.cs
@@ -11,7 +11,7 @@ namespace GalaxyCheck.Internal
                 .GetType()
                 .GetInterfaces()
                 .Where(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IGen<>))
-                .SingleOrDefault();
+                .Single();
 
             return reflectedGenType.GetGenericArguments().Single();
         }

--- a/src/GalaxyCheck/Internal/TypeExtensions.cs
+++ b/src/GalaxyCheck/Internal/TypeExtensions.cs
@@ -9,7 +9,7 @@ namespace GalaxyCheck.Internal
         public static bool IsAnonymousType(this Type type)
         {
             bool hasCompilerGeneratedAttribute = type.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Any();
-            bool nameContainsAnonymousType = type.FullName.Contains("AnonymousType");
+            bool nameContainsAnonymousType = type?.FullName?.Contains("AnonymousType") == true;
             bool isAnonymousType = hasCompilerGeneratedAttribute && nameContainsAnonymousType;
 
             return isAnonymousType;

--- a/src/GalaxyCheck/Properties/Reflect.cs
+++ b/src/GalaxyCheck/Properties/Reflect.cs
@@ -55,7 +55,7 @@ namespace GalaxyCheck
                     }
                     catch (TargetInvocationException ex)
                     {
-                        throw ex.InnerException;
+                        throw ex.InnerException!;
                     }
                 })
                 .Select(test => TestFactory.Create<object>(
@@ -72,11 +72,11 @@ namespace GalaxyCheck
                 {
                     try
                     {
-                        return (bool)methodInfo.Invoke(target, parameters);
+                        return (bool)methodInfo.Invoke(target, parameters)!;
                     }
                     catch (TargetInvocationException ex)
                     {
-                        throw ex.InnerException;
+                        throw ex.InnerException!;
                     }
                 })
                 .Select(test => TestFactory.Create<object>(
@@ -93,17 +93,17 @@ namespace GalaxyCheck
             select TestFactory.Create(
                 test.Input,
                 test.Output,
-                Enumerable.Concat(parameters, test.PresentedInput).ToArray());
+                Enumerable.Concat(parameters, test.PresentedInput!).ToArray());
 
         private static ReflectedPropertyHandler ToPureProperty => (methodInfo, target, _, _) =>
         {
             try
             {
-                return ((IGen<Test>)methodInfo.Invoke(target, new object[] { })).Select(test => test.Cast<object>());
+                return ((IGen<Test>)methodInfo.Invoke(target, new object[] { })!).Select(test => test.Cast<object>());
             }
             catch (TargetInvocationException ex)
             {
-                throw ex.InnerException;
+                throw ex.InnerException!;
             }
         };
 
@@ -111,11 +111,11 @@ namespace GalaxyCheck
         {
             try
             {
-                return (Property)methodInfo.Invoke(target, parameters);
+                return (Property)methodInfo.Invoke(target, parameters)!;
             }
             catch (TargetInvocationException ex)
             {
-                if (ex.InnerException.GetType() == typeof(PropertyPreconditionException))
+                if (ex.InnerException!.GetType() == typeof(PropertyPreconditionException))
                 {
                     return null;
                 }

--- a/src/GalaxyCheck/Properties/Test.cs
+++ b/src/GalaxyCheck/Properties/Test.cs
@@ -3,7 +3,9 @@ using System;
 
 namespace GalaxyCheck
 {
+#pragma warning disable IDE1006 // Naming Styles
     public interface Test
+#pragma warning restore IDE1006 // Naming Styles
     {
         object? Input { get; }
 
@@ -11,7 +13,9 @@ namespace GalaxyCheck
 
         object?[]? PresentedInput { get; }
 
+#pragma warning disable IDE1006 // Naming Styles
         public interface TestOutput
+#pragma warning restore IDE1006 // Naming Styles
         {
             TestResult Result { get; }
 
@@ -26,7 +30,9 @@ namespace GalaxyCheck
         }
     }
 
+#pragma warning disable IDE1006 // Naming Styles
     public interface Test<out T> : Test
+#pragma warning restore IDE1006 // Naming Styles
     {
         new T Input { get; }
     }

--- a/src/GalaxyCheck/Runners/Assert.cs
+++ b/src/GalaxyCheck/Runners/Assert.cs
@@ -65,7 +65,7 @@ namespace GalaxyCheck.Runners
             _counterexample = counterexample;
         }
 
-        public override string StackTrace => _counterexample.Exception?.StackTrace ?? base.StackTrace;
+        public override string StackTrace => _counterexample.Exception?.StackTrace ?? base.StackTrace!;
 
         private static string FormatMessage(Func<string, string>? formatMessage, string message) =>
             formatMessage == null


### PR DESCRIPTION
Removes external dependencies on:
- Microsoft.Bcl.HashCode
- System.Collections.Immutable

As they are now in the base framework.

`ISetGen` uses the new `IReadOnlySet` type.
