### PR TITLE
🌍 First end-to-end async implementation with GalaxyCheck.Xunit

### DIFF
--- a/src/GalaxyCheck.Xunit.Tests/IntegrationSample/AsyncTests.cs
+++ b/src/GalaxyCheck.Xunit.Tests/IntegrationSample/AsyncTests.cs
@@ -1,0 +1,138 @@
+﻿using GalaxyCheck;
+using GalaxyCheck.Gens;
+using GalaxyCheck.Gens.Injection.Int32;
+using Newtonsoft.Json;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IntegrationSample
+{
+    public class AsyncTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public AsyncTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Property]
+        public IGen<AsyncTest> InfalliblePurePropertyAsync() =>
+            from a in Gen.Int32().Between(0, 100)
+            select Property.ForTheseAsync(async () =>
+            {
+                await Task.Delay(1);
+                AnnounceTestInvocation(nameof(InfalliblePurePropertyAsync));
+            });
+
+        [Property]
+        public IGen<AsyncTest> FalliblePurePropertyAsync() =>
+            from a in Gen.Int32().Between(0, 100)
+            select Property.ForTheseAsync(async () =>
+            {
+                await Task.Delay(1);
+                AnnounceTestInvocation(nameof(FalliblePurePropertyAsync));
+                throw new Exception("Failed!");
+            });
+
+        [Property]
+        public async Task InfallibleVoidPropertyAsync([Between(0, 100)] int x)
+        {
+            await Task.Delay(1);
+            AnnounceTestInvocation(nameof(InfallibleVoidPropertyAsync));
+        }
+
+        [Property]
+        public async Task FallibleVoidPropertyAsync([Between(0, 100)] int x)
+        {
+            await Task.Delay(1);
+            AnnounceTestInvocation(nameof(FallibleVoidPropertyAsync));
+            throw new Exception("Failed!");
+        }
+
+        [Property]
+        public async Task InfallibleBooleanPropertyAsync([Between(0, 100)] int x)
+        {
+            await Task.Delay(1);
+            AnnounceTestInvocation(nameof(InfallibleBooleanPropertyAsync));
+        }
+
+        [Property]
+        public async Task FallibleBooleanPropertyAsync([Between(0, 100)] int x)
+        {
+            await Task.Delay(1);
+            AnnounceTestInvocation(nameof(FallibleBooleanPropertyAsync));
+            throw new Exception("Failed!");
+        }
+
+        [Property]
+        public AsyncProperty InfallibleReturnedPropertyAsync()
+        {
+            AnnounceTestInvocation(nameof(InfallibleReturnedPropertyAsync));
+            return Gen.Int32().Between(0, 100).ForAllAsync(async y =>
+            { 
+                await Task.Delay(1);
+            });
+        }
+
+        [Property]
+        public AsyncProperty FallibleReturnedPropertyAsync()
+        {
+            AnnounceTestInvocation(nameof(FallibleReturnedPropertyAsync));
+            return Gen.Int32().Between(0, 100).ForAllAsync(async y =>
+            {
+                await Task.Delay(1);
+                throw new Exception("Failed!");
+            });
+        }
+
+        public class GenFactoryWhereIntsAreNonNegativeAttribute : GenFactoryAttribute
+        {
+            public override IGenFactory Value => Gen.Factory().RegisterType(Gen.Int32().GreaterThanEqual(0));
+        }
+
+        [Property]
+        [GenFactoryWhereIntsAreNonNegative]
+        public async Task PropertyWithGenFromGenFactoryAsync(int x)
+        {
+            await Task.Delay(1);
+            AnnounceTestInvocation(nameof(PropertyWithGenFromGenFactoryAsync), new [] { x });
+            Assert.True(x >= 0, "They are not negative!");
+        }
+
+        private static IGen<int> EvenInt32 => Gen.Int32().Where(x => x % 2 == 0);
+
+        [Property]
+        public async Task PropertyWithGenFromMemberGenAsync([MemberGen(nameof(EvenInt32))] int x)
+        {
+            await Task.Delay(1);
+            AnnounceTestInvocation(nameof(PropertyWithGenFromGenFactoryAsync), new[] { x });
+            Assert.True(x % 2 != 1, "They are not odd!");
+        }
+
+        [Sample]
+        public IGen<AsyncTest> SamplePurePropertyAsync() =>
+            from a in Gen.Int32().Between(0, 100)
+            select Property.ForTheseAsync(async () =>
+            {
+                await Task.Delay(1);
+            });
+
+        [Sample]
+        public async Task SampleVoidPropertyAsync([Between(0, 100)] int x)
+        {
+            await Task.Delay(1);
+        }
+
+        private void AnnounceTestInvocation(string testName, params object[] injectedValues)
+        {
+            _testOutputHelper.WriteLine(JsonConvert.SerializeObject(new
+            {
+                testName,
+                injectedValues
+            }));
+        }
+    }
+}

--- a/src/GalaxyCheck.Xunit.Tests/IntegrationSample/Tests.cs
+++ b/src/GalaxyCheck.Xunit.Tests/IntegrationSample/Tests.cs
@@ -61,16 +61,16 @@ namespace IntegrationSample
         }
 
         [Property]
-        public Property InfallibleNestedProperty()
+        public Property InfallibleReturnedProperty()
         {
-            AnnounceTestInvocation(nameof(InfallibleNestedProperty));
+            AnnounceTestInvocation(nameof(InfallibleReturnedProperty));
             return Gen.Int32().Between(0, 100).ForAll(y => { });
         }
 
         [Property]
-        public Property FallibleNestedProperty()
+        public Property FallibleReturnedProperty()
         {
-            AnnounceTestInvocation(nameof(FallibleNestedProperty));
+            AnnounceTestInvocation(nameof(FallibleReturnedProperty));
             return Gen.Int32().Between(0, 100).ForAll(y => { throw new Exception("Failed!"); });
         }
 

--- a/src/GalaxyCheck.Xunit.Tests/IntegrationTests.cs
+++ b/src/GalaxyCheck.Xunit.Tests/IntegrationTests.cs
@@ -20,103 +20,51 @@ namespace Tests
             _fixture = fixture;
         }
 
-        [Fact]
-        public void InfalliblePureProperty()
+        [Theory]
+        [InlineData("InfalliblePureProperty")]
+        [InlineData("InfalliblePurePropertyAsync")]
+        [InlineData("InfallibleVoidProperty")]
+        [InlineData("InfallibleVoidPropertyAsync")]
+        [InlineData("InfallibleBooleanProperty")]
+        [InlineData("InfallibleBooleanPropertyAsync")]
+        [InlineData("InfallibleReturnedProperty")]
+        [InlineData("InfallibleReturnedPropertyAsync")]
+        [InlineData("PropertyWithGenFromGenFactory")]
+        [InlineData("PropertyWithGenFromGenFactoryAsync")]
+        [InlineData("PropertyWithGenFromMemberGen")]
+        [InlineData("PropertyWithGenFromMemberGenAsync")]
+        public void PassingProperties(string testName)
         {
-            var testResult = _fixture.FindTestResult(nameof(InfalliblePureProperty));
+            var testResult = _fixture.FindTestResult(testName);
 
             testResult.Outcome.Should().Be("Passed");
         }
 
-        [Fact]
-        public void FalliblePureProperty()
+        [Theory]
+        [InlineData("FalliblePureProperty")]
+        [InlineData("FalliblePurePropertyAsync")]
+        [InlineData("FallibleVoidProperty")]
+        [InlineData("FallibleVoidPropertyAsync")]
+        [InlineData("FallibleBooleanProperty")]
+        [InlineData("FallibleBooleanPropertyAsync")]
+        [InlineData("FallibleReturnedProperty")]
+        [InlineData("FallibleReturnedPropertyAsync")]
+        public void FailingProperties(string testName)
         {
-            var testResult = _fixture.FindTestResult(nameof(FalliblePureProperty));
+            var testResult = _fixture.FindTestResult(testName);
 
             testResult.Outcome.Should().Be("Failed");
             testResult.Message.Should().StartWith("GalaxyCheck.Runners.PropertyFailedException");
         }
 
-        [Fact]
-        public void InfallibleVoidProperty()
+        [Theory]
+        [InlineData("SamplePureProperty")]
+        [InlineData("SamplePurePropertyAsync")]
+        [InlineData("SampleVoidProperty")]
+        [InlineData("SampleVoidPropertyAsync")]
+        public void SampledProperties(string testName)
         {
-            var testResult = _fixture.FindTestResult(nameof(InfallibleVoidProperty));
-
-            testResult.Outcome.Should().Be("Passed");
-        }
-
-        [Fact]
-        public void FallibleVoidProperty()
-        {
-            var testResult = _fixture.FindTestResult(nameof(FallibleVoidProperty));
-
-            testResult.Outcome.Should().Be("Failed");
-            testResult.Message.Should().StartWith("GalaxyCheck.Runners.PropertyFailedException");
-        }
-
-        [Fact]
-        public void InfallibleBooleanProperty()
-        {
-            var testResult = _fixture.FindTestResult(nameof(InfallibleBooleanProperty));
-
-            testResult.Outcome.Should().Be("Passed");
-        }
-
-        [Fact]
-        public void FallibleBooleanProperty()
-        {
-            var testResult = _fixture.FindTestResult(nameof(FallibleBooleanProperty));
-
-            testResult.Outcome.Should().Be("Failed");
-            testResult.Message.Should().StartWith("GalaxyCheck.Runners.PropertyFailedException");
-        }
-
-        [Fact]
-        public void InfallibleNestedProperty()
-        {
-            var testResult = _fixture.FindTestResult(nameof(InfallibleNestedProperty));
-
-            testResult.Outcome.Should().Be("Passed");
-        }
-
-        [Fact]
-        public void FallibleNestedProperty()
-        {
-            var testResult = _fixture.FindTestResult(nameof(FallibleNestedProperty));
-
-            testResult.Outcome.Should().Be("Failed");
-            testResult.Message.Should().StartWith("GalaxyCheck.Runners.PropertyFailedException");
-        }
-
-        [Fact]
-        public void PropertyWithGenFromGenFactory()
-        {
-            var testResult = _fixture.FindTestResult(nameof(PropertyWithGenFromGenFactory));
-
-            testResult.Outcome.Should().Be("Passed");
-        }
-
-        [Fact]
-        public void PropertyWithGenFromMemberGen()
-        {
-            var testResult = _fixture.FindTestResult(nameof(PropertyWithGenFromMemberGen));
-
-            testResult.Outcome.Should().Be("Passed");
-        }
-
-        [Fact]
-        public void SamplePureProperty()
-        {
-            var testResult = _fixture.FindTestResult(nameof(SamplePureProperty));
-
-            testResult.Outcome.Should().Be("Failed");
-            testResult.Message.Should().StartWith("GalaxyCheck.SampleException : Test case failed to prevent false-positives.");
-        }
-
-        [Fact]
-        public void SampleVoidProperty()
-        {
-            var testResult = _fixture.FindTestResult(nameof(SampleVoidProperty));
+            var testResult = _fixture.FindTestResult(testName);
 
             testResult.Outcome.Should().Be("Failed");
             testResult.Message.Should().StartWith("GalaxyCheck.SampleException : Test case failed to prevent false-positives.");

--- a/src/GalaxyCheck.Xunit/Internal/DefaultPropertyFactory.cs
+++ b/src/GalaxyCheck.Xunit/Internal/DefaultPropertyFactory.cs
@@ -6,10 +6,10 @@ namespace GalaxyCheck.Xunit.Internal
 {
     internal class DefaultPropertyFactory : IPropertyFactory
     {
-        public Property CreateProperty(
+        public AsyncProperty CreateProperty(
             MethodInfo methodInfo,
             object? target,
             IGenFactory? genFactory,
-            IReadOnlyDictionary<int, IGen> customGens) => Property.Reflect(methodInfo, target, genFactory, customGens);
+            IReadOnlyDictionary<int, IGen> customGens) => Property.ReflectAsync(methodInfo, target, genFactory, customGens);
     }
 }

--- a/src/GalaxyCheck.Xunit/Internal/IPropertyFactory.cs
+++ b/src/GalaxyCheck.Xunit/Internal/IPropertyFactory.cs
@@ -6,7 +6,7 @@ namespace GalaxyCheck.Xunit.Internal
 {
     public interface IPropertyFactory
     {
-        Property CreateProperty(
+        AsyncProperty CreateProperty(
             MethodInfo methodInfo,
             object? target,
             IGenFactory? genFactory,

--- a/src/GalaxyCheck.Xunit/Internal/IPropertyRunner.cs
+++ b/src/GalaxyCheck.Xunit/Internal/IPropertyRunner.cs
@@ -1,10 +1,11 @@
 ﻿using GalaxyCheck.Gens;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace GalaxyCheck.Xunit.Internal
 {
     internal record PropertyRunParameters(
-        Property Property,
+        AsyncProperty Property,
         int Iterations,
         int ShrinkLimit,
         string? Replay,
@@ -13,6 +14,6 @@ namespace GalaxyCheck.Xunit.Internal
 
     internal interface IPropertyRunner
     {
-        void Run(PropertyRunParameters parameters, ITestOutputHelper testOutputHelper);
+        Task Run(PropertyRunParameters parameters, ITestOutputHelper testOutputHelper);
     }
 }

--- a/src/GalaxyCheck.Xunit/Internal/PropertyAssertRunner.cs
+++ b/src/GalaxyCheck.Xunit/Internal/PropertyAssertRunner.cs
@@ -1,13 +1,13 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace GalaxyCheck.Xunit.Internal
 {
     internal class PropertyAssertRunner : IPropertyRunner
     {
-        public void Run(PropertyRunParameters parameters, ITestOutputHelper testOutputHelper)
-        {
-            parameters.Property.Assert(
+        public Task Run(PropertyRunParameters parameters, ITestOutputHelper testOutputHelper) =>
+            parameters.Property.AssertAsync(
                 replay: parameters.Replay,
                 seed: parameters.Seed,
                 size: parameters.Size,
@@ -15,6 +15,5 @@ namespace GalaxyCheck.Xunit.Internal
                 shrinkLimit: parameters.ShrinkLimit,
                 formatReproduction: (newReplay) => $"{Environment.NewLine}    [Replay(\"{newReplay}\")]",
                 formatMessage: (x) => Environment.NewLine + Environment.NewLine + x);
-        }
     }
 }

--- a/src/GalaxyCheck.Xunit/Internal/PropertySampleRunner.cs
+++ b/src/GalaxyCheck.Xunit/Internal/PropertySampleRunner.cs
@@ -1,16 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace GalaxyCheck.Xunit.Internal
 {
     internal class PropertySampleRunner : IPropertyRunner
     {
-        public void Run(PropertyRunParameters parameters, ITestOutputHelper testOutputHelper)
+        public async Task Run(PropertyRunParameters parameters, ITestOutputHelper testOutputHelper)
         {
             var log = new List<string>();
 
-            parameters.Property.Print(
+            await parameters.Property.PrintAsync(
                 stdout: log.Add,
                 seed: parameters.Seed,
                 size: parameters.Size,

--- a/src/GalaxyCheck.Xunit/Internal/PropertyTestCase.cs
+++ b/src/GalaxyCheck.Xunit/Internal/PropertyTestCase.cs
@@ -27,7 +27,7 @@ namespace GalaxyCheck.Xunit.Internal
         {
         }
 
-        public override Task<RunSummary> RunAsync(
+        public override async Task<RunSummary> RunAsync(
             IMessageSink diagnosticMessageSink,
             IMessageBus messageBus,
             object[] constructorArguments,
@@ -74,22 +74,22 @@ namespace GalaxyCheck.Xunit.Internal
             }
             catch (Exception exception)
             {
-                return Fail(exception);
+                return await Fail(exception);
             }
 
             if (propertyInitResult.ShouldSkip)
             {
-                return Skip(propertyInitResult.SkipReason!);
+                return await Skip(propertyInitResult.SkipReason!);
             }
 
             try
             {
-                propertyInitResult.Runner.Run(propertyInitResult.Parameters, testOutputHelper);
-                return Pass();
+                await propertyInitResult.Runner.Run(propertyInitResult.Parameters, testOutputHelper);
+                return await Pass();
             }
             catch (Exception propertyFailedException)
             {
-                return Fail(propertyFailedException);
+                return await Fail(propertyFailedException);
             }
         }
     }

--- a/src/GalaxyCheck/Properties/ForAllAsync.cs
+++ b/src/GalaxyCheck/Properties/ForAllAsync.cs
@@ -9,14 +9,14 @@ namespace GalaxyCheck
         public static AsyncProperty<object[]> NullaryAsync(Func<Task<bool>> func) => new AsyncProperty<object[]>(
             Gen.Constant(new object[] { }).Select(x => TestFactory.Create<object[]>(
                 x,
-                func,
+                () => new ValueTask<bool>(func()),
                 x)));
 
         public static AsyncProperty<T0> ForAllAsync<T0>(IGen<T0> gen0, Func<T0, Task<bool>> func) =>
             new AsyncProperty<T0>(
                 gen0.Select(x => TestFactory.Create(
                     x,
-                    () => func(x),
+                    () => new ValueTask<bool>(func(x)),
                     new object?[] { x })));
 
         public static AsyncProperty<(T0, T1)> ForAllAsync<T0, T1>(
@@ -25,7 +25,7 @@ namespace GalaxyCheck
             Func<T0, T1, Task<bool>> func) => new AsyncProperty<(T0, T1)>(
                 Gen.Zip(gen0, gen1).Select(tuple => TestFactory.Create(
                     tuple,
-                    () => func(tuple.Item1, tuple.Item2),
+                    () => new ValueTask<bool>(func(tuple.Item1, tuple.Item2)),
                     new object?[] { tuple.Item1, tuple.Item2 })));
 
         public static AsyncProperty<(T0, T1, T2)> ForAllAsync<T0, T1, T2>(
@@ -35,7 +35,7 @@ namespace GalaxyCheck
             Func<T0, T1, T2, Task<bool>> func) => new AsyncProperty<(T0, T1, T2)>(
                 Gen.Zip(gen0, gen1, gen2).Select(tuple => TestFactory.Create(
                     tuple,
-                    () => func(tuple.Item1, tuple.Item2, tuple.Item3),
+                    () => new ValueTask<bool>(func(tuple.Item1, tuple.Item2, tuple.Item3)),
                     new object?[] { tuple.Item1, tuple.Item2, tuple.Item3 })));
 
         public static AsyncProperty<(T0, T1, T2, T3)> ForAllAsync<T0, T1, T2, T3>(
@@ -46,7 +46,7 @@ namespace GalaxyCheck
             Func<T0, T1, T2, T3, Task<bool>> func) => new AsyncProperty<(T0, T1, T2, T3)>(
                 Gen.Zip(gen0, gen1, gen2, gen3).Select(tuple => TestFactory.Create(
                     tuple,
-                    () => func(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4),
+                    () => new ValueTask<bool>(func(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4)),
                     new object?[] { tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4 })));
 
         public static AsyncProperty<object[]> NullaryAsync(Func<Task> func) => NullaryAsync(func.AsTrueFunc());

--- a/src/GalaxyCheck/Properties/ForTheseAsync.cs
+++ b/src/GalaxyCheck/Properties/ForTheseAsync.cs
@@ -6,11 +6,11 @@ namespace GalaxyCheck
 {
     public partial class Property
     {
-        public static AsyncTest<object> ForTheseAsync(Func<Task<bool>> func) => TestFactory.Create<object>(
+        public static AsyncTest ForTheseAsync(Func<Task<bool>> func) => TestFactory.Create(
             null!,
-            () => func(),
+            () => new ValueTask<bool>(func()),
             null);
 
-        public static AsyncTest<object> ForTheseAsync(Func<Task> func) => ForTheseAsync(func.AsTrueFunc());
+        public static AsyncTest ForTheseAsync(Func<Task> func) => ForTheseAsync(func.AsTrueFunc());
     }
 }

--- a/src/GalaxyCheck/Properties/Test.cs
+++ b/src/GalaxyCheck/Properties/Test.cs
@@ -23,7 +23,7 @@ namespace GalaxyCheck
     {
     }
 
-    public interface AsyncTest<out T> : TestInput<T, Task<TestOutput>>
+    public interface AsyncTest<out T> : TestInput<T, ValueTask<TestOutput>>
     {
     }
 
@@ -39,11 +39,7 @@ namespace GalaxyCheck
 
         public static AsyncTest<T> AsAsync<T>(this Test<T> test) => TestFactory.Create<T>(
             test.Input,
-            new Lazy<Task<TestOutput>>(async () =>
-            {
-                await Task.CompletedTask;
-                return test.Output.Value;
-            }),
+            new Lazy<ValueTask<TestOutput>>(() => ValueTask.FromResult(test.Output.Value)),
             test.PresentedInput);
 
     }

--- a/src/GalaxyCheck/Properties/TestFactory.cs
+++ b/src/GalaxyCheck/Properties/TestFactory.cs
@@ -43,26 +43,26 @@ namespace GalaxyCheck.Properties
             }
         });
 
-        private record AsyncTestImpl<T>(T Input, Lazy<Task<TestOutput>> Output, IReadOnlyList<object?>? PresentedInput) : AsyncTest<T>;
+        private record AsyncTestImpl<T>(T Input, Lazy<ValueTask<TestOutput>> Output, IReadOnlyList<object?>? PresentedInput) : AsyncTest<T>;
 
-        private record AsyncTestImpl(object? Input, Lazy<Task<TestOutput>> Output, IReadOnlyList<object?>? PresentedInput) : AsyncTest;
+        private record AsyncTestImpl(object? Input, Lazy<ValueTask<TestOutput>> Output, IReadOnlyList<object?>? PresentedInput) : AsyncTest;
 
-        public static AsyncTest<T> Create<T>(T input, Lazy<Task<TestOutput>> output, IReadOnlyList<object?>? presentedInput)
+        public static AsyncTest<T> Create<T>(T input, Lazy<ValueTask<TestOutput>> output, IReadOnlyList<object?>? presentedInput)
         {
             return new AsyncTestImpl<T>(input, output, presentedInput);
         }
 
-        public static AsyncTest<T> Create<T>(T input, Func<Task<bool>> generateOutput, IReadOnlyList<object?>? presentedInput)
+        public static AsyncTest<T> Create<T>(T input, Func<ValueTask<bool>> generateOutput, IReadOnlyList<object?>? presentedInput)
         {
             return new AsyncTestImpl<T>(input, AnalyzeBooleanOutput(generateOutput), presentedInput);
         }
 
-        public static AsyncTest Create(object[] input, Func<Task<bool>> generateOutput, IReadOnlyList<object?>? presentedInput)
+        public static AsyncTest Create(object[] input, Func<ValueTask<bool>> generateOutput, IReadOnlyList<object?>? presentedInput)
         {
             return new AsyncTestImpl(input, AnalyzeBooleanOutput(generateOutput), presentedInput);
         }
 
-        private static Lazy<Task<TestOutput>> AnalyzeBooleanOutput(Func<Task<bool>> generateOutput) => new Lazy<Task<TestOutput>>(async () =>
+        private static Lazy<ValueTask<TestOutput>> AnalyzeBooleanOutput(Func<ValueTask<bool>> generateOutput) => new Lazy<ValueTask<TestOutput>>(async () =>
         {
             try
             {

--- a/src/GalaxyCheck/Runners/PresentationalSample.cs
+++ b/src/GalaxyCheck/Runners/PresentationalSample.cs
@@ -101,7 +101,7 @@ namespace GalaxyCheck.Runners.Sample
         {
             // Create a test that always passes using the same input. We don't care if a property passes or fails when
             // we're sampling the input.
-            return TestFactory.Create(test.Input, () => Task.FromResult(true), test.PresentedInput);
+            return TestFactory.Create(test.Input, () => ValueTask.FromResult(true), test.PresentedInput);
         }
 
         private static SampleWithMetricsResult<IReadOnlyList<object?>> ExtractSampleFromCheckResult<T>(CheckResult<T> checkResult)


### PR DESCRIPTION
GalaxyCheck.Xunit now calls `ReflectAsync` instead of `Reflect` on all test methods, so use `ValueTask`s internally instead of `Task`s so performance of non-async properties through Xunit is not hampered.
