### PR TITLE
🌍 Downgrade analyzers to netstandard2.0

### DIFF
--- a/src/GalaxyCheck.Tests/RunnerTests/AssertTests/AboutExhaustion.cs
+++ b/src/GalaxyCheck.Tests/RunnerTests/AssertTests/AboutExhaustion.cs
@@ -25,7 +25,7 @@ namespace Tests.V2.RunnerTests.AssertTests
 
                         test.Should().Throw<GalaxyCheck.Exceptions.GenExhaustionException>();
                     },
-                    TimeSpan.FromSeconds(20));
+                    TimeSpan.FromSeconds(60));
             }
         }
 
@@ -43,7 +43,7 @@ namespace Tests.V2.RunnerTests.AssertTests
 
                         await test.Should().ThrowAsync<GalaxyCheck.Exceptions.GenExhaustionException>();
                     },
-                    TimeSpan.FromSeconds(20));
+                    TimeSpan.FromSeconds(60));
             }
         }
     }

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/AboutExhaustion.cs
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/AboutExhaustion.cs
@@ -26,7 +26,7 @@ namespace Tests.V2.RunnerTests.CheckTests
                         test.Should().Throw<GalaxyCheck.Exceptions.GenExhaustionException>();
 
                     },
-                    TimeSpan.FromSeconds(20));
+                    TimeSpan.FromSeconds(60));
             }
 
             [Property(Iterations = 1)]
@@ -41,7 +41,7 @@ namespace Tests.V2.RunnerTests.CheckTests
 
                         test.Should().Throw<GalaxyCheck.Exceptions.GenExhaustionException>();
                     },
-                    TimeSpan.FromSeconds(20));
+                    TimeSpan.FromSeconds(60));
             }
         }
 
@@ -60,7 +60,7 @@ namespace Tests.V2.RunnerTests.CheckTests
                         await test.Should().ThrowAsync<GalaxyCheck.Exceptions.GenExhaustionException>();
 
                     },
-                    TimeSpan.FromSeconds(20));
+                    TimeSpan.FromSeconds(60));
             }
 
             [Property(Iterations = 1)]
@@ -79,7 +79,7 @@ namespace Tests.V2.RunnerTests.CheckTests
 
                         await test.Should().ThrowAsync<GalaxyCheck.Exceptions.GenExhaustionException>();
                     },
-                    TimeSpan.FromSeconds(20));
+                    TimeSpan.FromSeconds(60));
             }
 
         }

--- a/src/GalaxyCheck.Tests/RunnerTests/PrintTests/AboutExhaustion.cs
+++ b/src/GalaxyCheck.Tests/RunnerTests/PrintTests/AboutExhaustion.cs
@@ -25,7 +25,7 @@ namespace Tests.V2.RunnerTests.PrintTests
 
                         test.Should().Throw<GalaxyCheck.Exceptions.GenExhaustionException>();
                     },
-                    TimeSpan.FromSeconds(20));
+                    TimeSpan.FromSeconds(60));
             }
         }
 
@@ -43,7 +43,7 @@ namespace Tests.V2.RunnerTests.PrintTests
 
                         await test.Should().ThrowAsync<GalaxyCheck.Exceptions.GenExhaustionException>();
                     },
-                    TimeSpan.FromSeconds(20));
+                    TimeSpan.FromSeconds(60));
             }
         }
     }

--- a/src/GalaxyCheck.Xunit.CodeAnalysis/GalaxyCheck.Xunit.CodeAnalysis.csproj
+++ b/src/GalaxyCheck.Xunit.CodeAnalysis/GalaxyCheck.Xunit.CodeAnalysis.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NuspecFile>GalaxyCheck.Xunit.CodeAnalysis.nuspec</NuspecFile>
     <NuspecProperties>PackageVersion=$(PackageVersion)</NuspecProperties>
     <NuspecBasePath></NuspecBasePath>

--- a/src/GalaxyCheck.Xunit.CodeAnalysis/GalaxyCheck.Xunit.CodeAnalysis.nuspec
+++ b/src/GalaxyCheck.Xunit.CodeAnalysis/GalaxyCheck.Xunit.CodeAnalysis.nuspec
@@ -11,8 +11,8 @@
     <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
-    <file src="bin\Release\net6.0\GalaxyCheck.Xunit.CodeAnalysis.pdb" target="lib" />
-    <file src="bin\Release\net6.0\*.dll" target="analyzers\dotnet\cs" exclude="**\Microsoft.CodeAnalysis.*;**\System.Collections.Immutable.*;**\System.Reflection.Metadata.*;**\System.Composition.*" />
+    <file src="bin\Release\netstandard2.0\GalaxyCheck.Xunit.CodeAnalysis.pdb" target="lib" />
+    <file src="bin\Release\netstandard2.0\*.dll" target="analyzers\dotnet\cs" exclude="**\Microsoft.CodeAnalysis.*;**\System.Collections.Immutable.*;**\System.Reflection.Metadata.*;**\System.Composition.*" />
     <file src="tools\*.ps1" target="tools\" />
   </files>
 </package>

--- a/src/GalaxyCheck.Xunit/GalaxyCheck.Xunit.nuspec
+++ b/src/GalaxyCheck.Xunit/GalaxyCheck.Xunit.nuspec
@@ -9,7 +9,7 @@
         <license type="expression">MIT</license>
         <tags>GalaxyCheck;Property-Based Testing;Test Framework;Xunit</tags>
         <dependencies>
-            <group targetFramework=".NETStandard2.0">
+            <group targetFramework="net6.0">
                 <dependency id="xunit.extensibility.execution" version="2.4.1" exclude="Build,Analyzers" />
                 <dependency id="GalaxyCheck" version="$PackageVersion$" exclude="Build,Analyzers" />
                 <dependency id="GalaxyCheck.Xunit.CodeAnalysis" version="$PackageVersion$" />


### PR DESCRIPTION
AFAICT, there's not much guidance on how to author analyzers in net6.0 yet. Popular analyzer packages are still targeting netstandard.
