### PR TITLE
🌍 Improve reflected generator stability

### DIFF
--- a/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutGeneratingDeepObjects.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutGeneratingDeepObjects.cs
@@ -45,7 +45,6 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
         [Property]
         public NebulaCheck.IGen<Test> IfTheClassHasARecursiveProperty_ItErrors() =>
-            from value in DomainGen.Any()
             from seed in DomainGen.Seed()
             from size in DomainGen.Size()
             select Property.ForThese(() =>

--- a/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutStability.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutStability.cs
@@ -1,0 +1,76 @@
+﻿using FluentAssertions;
+using GalaxyCheck;
+using static Tests.V2.DomainGenAttributes;
+
+namespace Tests.V2.GenTests.ReflectedGenTests
+{
+    public class AboutStability
+    {
+        private class ClassWithPropertiesV1
+        {
+            public int Property { get; set; }
+        }
+
+        private class ClassWithPropertiesV2
+        {
+            public int A_Property { get; set; }
+            public int Property { get; set; }
+            public int Z_Property { get; set; }
+        }
+
+        [NebulaCheck.Property]
+        public void AddingNewPropertiesDoesNotChangeHowExistingPropertiesAreGenerated([Seed] int seed, [Size] int size)
+        {
+            var gen0 = Gen.Create<ClassWithPropertiesV1>();
+            var sample0 = gen0.SampleOne(seed: seed, size: size);
+
+            var gen1 = Gen.Create<ClassWithPropertiesV2>();
+            var sample1 = gen1.SampleOne(seed: seed, size: size);
+
+            sample1.Property.Should().Be(sample0.Property);
+        }
+
+        private class ClassWithFieldsV1
+        {
+            public int Field = 0;
+        }
+
+        private class ClassWithFieldsV2
+        {
+            public int A_Field = 0;
+            public int Field = 0;
+            public int Z_Field = 0;
+        }
+
+        [NebulaCheck.Property]
+        public void AddingNewFieldsDoesNotChangeHowExistingFieldsAreGenerated([Seed] int seed, [Size] int size)
+        {
+            var gen0 = Gen.Create<ClassWithFieldsV1>();
+            var sample0 = gen0.SampleOne(seed: seed, size: size);
+
+            var gen1 = Gen.Create<ClassWithFieldsV2>();
+            var sample1 = gen1.SampleOne(seed: seed, size: size);
+
+            sample1.Field.Should().Be(sample0.Field);
+        }
+
+        private record RecordV1(int Property);
+
+        private record RecordV2(
+            int A_Property,
+            int Property,
+            int Z_Property);
+
+        [NebulaCheck.Property]
+        public void AddingNewPropertiesToStandardRecordConstructorDoesNotChangeHowExistingPropertiesAreGenerated([Seed] int seed, [Size] int size)
+        {
+            var gen0 = Gen.Create<RecordV1>();
+            var sample0 = gen0.SampleOne(seed: seed, size: size);
+
+            var gen1 = Gen.Create<RecordV2>();
+            var sample1 = gen1.SampleOne(seed: seed, size: size);
+
+            sample1.Property.Should().Be(sample0.Property);
+        }
+    }
+}

--- a/src/GalaxyCheck/Gens/Internal/BaseGen.cs
+++ b/src/GalaxyCheck/Gens/Internal/BaseGen.cs
@@ -27,4 +27,23 @@ namespace GalaxyCheck.Gens.Internal
             IEnumerable<IGenIteration> IGenAdvanced.Run(GenParameters parameters) => _gen.Run(parameters);
         }
     }
+
+    internal abstract class BaseGen : IGen
+    {
+        public IGenAdvanced Advanced => new GenAdvanced(this);
+
+        protected abstract IEnumerable<IGenIteration> Run(GenParameters parameters);
+
+        private class GenAdvanced : IGenAdvanced
+        {
+            private readonly BaseGen _gen;
+
+            public GenAdvanced(BaseGen gen)
+            {
+                _gen = gen;
+            }
+
+            public IEnumerable<IGenIteration> Run(GenParameters parameters) => _gen.Run(parameters);
+        }
+    }
 }

--- a/src/GalaxyCheck/Gens/Internal/ConfiguredParametersGen.cs
+++ b/src/GalaxyCheck/Gens/Internal/ConfiguredParametersGen.cs
@@ -1,0 +1,55 @@
+﻿using GalaxyCheck.Gens.Internal;
+using GalaxyCheck.Gens.Iterations;
+using GalaxyCheck.Gens.Iterations.Generic;
+using GalaxyCheck.Gens.Parameters;
+using System;
+using System.Collections.Generic;
+
+namespace GalaxyCheck
+{
+    public static partial class Extensions
+    {
+        internal static IGen<T> WithTransformedParameters<T>(
+            this IGen<T> gen,
+            Func<GenParameters, GenParameters> transformParameters) =>
+                new ConfiguredParametersGen<T>(gen, transformParameters);
+
+        internal static IGen WithTransformedParameters(
+            this IGen gen,
+            Func<GenParameters, GenParameters> transformParameters) =>
+                new ConfiguredParametersGen(gen, transformParameters);
+    }
+}
+
+namespace GalaxyCheck.Gens.Internal
+{
+    internal class ConfiguredParametersGen<T> : BaseGen<T>
+    {
+        private readonly IGen<T> _gen;
+        private readonly Func<GenParameters, GenParameters> _transformParameters;
+
+        public ConfiguredParametersGen(IGen<T> gen, Func<GenParameters, GenParameters> transformParameters)
+        {
+            _gen = gen;
+            _transformParameters = transformParameters;
+        }
+
+        protected override IEnumerable<IGenIteration<T>> Run(GenParameters parameters) =>
+            _gen.Advanced.Run(_transformParameters(parameters));
+    }
+
+    internal class ConfiguredParametersGen : BaseGen
+    {
+        private readonly IGen _gen;
+        private readonly Func<GenParameters, GenParameters> _transformParameters;
+
+        public ConfiguredParametersGen(IGen gen, Func<GenParameters, GenParameters> transformParameters)
+        {
+            _gen = gen;
+            _transformParameters = transformParameters;
+        }
+
+        protected override IEnumerable<IGenIteration> Run(GenParameters parameters) =>
+            _gen.Advanced.Run(_transformParameters(parameters));
+    }
+}

--- a/src/GalaxyCheck/Gens/Parameters/GenParameters.cs
+++ b/src/GalaxyCheck/Gens/Parameters/GenParameters.cs
@@ -17,11 +17,6 @@
             return new GenParameters(Internal.Rng.Create(seed), new Size(size));
         }
 
-        public static GenParameters Create(int size)
-        {
-            return new GenParameters(Internal.Rng.Spawn(), new Size(size));
-        }
-
         internal static GenParameters Create(IRng rng, Size size)
         {
             return new GenParameters(rng, size);

--- a/src/GalaxyCheck/Gens/Parameters/IRng.cs
+++ b/src/GalaxyCheck/Gens/Parameters/IRng.cs
@@ -37,6 +37,14 @@
         IRng Fork();
 
         /// <summary>
+        /// Creates a new RNG with the given seed. This will affect how the next value is generated, but not disrupt
+        /// any other properties of the RNG.
+        /// </summary>
+        /// <param name="seed">The next seed to use.</param>
+        /// <returns></returns>
+        IRng Influence(int seed);
+
+        /// <summary>
         /// Generates a random 64-bit integer, based off of the seed, and some given boundaries. This is a pure
         /// function and will always return the same integer, given the same boundaries.
         /// </summary>

--- a/src/GalaxyCheck/Gens/Parameters/Internal/Rng.cs
+++ b/src/GalaxyCheck/Gens/Parameters/Internal/Rng.cs
@@ -36,6 +36,8 @@ namespace GalaxyCheck.Gens.Parameters.Internal
 
         public IRng Fork() => Create((Family + 1) * -1521134295 + Order);
 
+        public IRng Influence(int seed) => new Rng(Family, seed, Order);
+
         public long Value(long min, long max)
         {
             if (min > max) throw new ArgumentOutOfRangeException(nameof(min), "'min' cannot be greater than 'max'");

--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlerExtensions.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlerExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿using GalaxyCheck.Gens.Internal;
+using GalaxyCheck.Gens.Iterations;
+using GalaxyCheck.Gens.Parameters;
+using GalaxyCheck.Gens.Parameters.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace GalaxyCheck.Gens.ReflectedGenHelpers
 {
@@ -7,7 +14,35 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers
         public static IGen CreateGen(
             this IReflectedGenHandler innerHandler,
             Type type,
-            ReflectedGenHandlerContext context) =>
-                innerHandler.CreateGen(innerHandler, type, context);
+            ReflectedGenHandlerContext context) => innerHandler.CreateGen(innerHandler, type, context);
+
+        public static IGen CreateNamedGen(
+            this IReflectedGenHandler innerHandler,
+            Type elementType,
+            string elementName,
+            ReflectedGenHandlerContext parentContext)
+        {
+            var context = parentContext.Next(elementName, elementType);
+            return innerHandler
+                .CreateGen(elementType, context)
+                .WithTransformedParameters(parameters =>
+                {
+                    var pathDependendentSeed = Encoding.Unicode
+                        .GetBytes(context.MemberPath)
+                        .Select(x => (int)x)
+                        .Aggregate((acc, curr) =>
+                        {
+                            unchecked
+                            {
+                                return acc + curr;
+                            }
+                        });
+
+                    var nextRng = parameters.Rng.Influence(pathDependendentSeed);
+                    var nextParameters = GenParameters.Create(Rng.Create(pathDependendentSeed), parameters.Size);
+
+                    return nextParameters;
+                });
+        }
     }
 }

--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/NonDefaultConstructorReflectedGenHandler.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlers/NonDefaultConstructorReflectedGenHandler.cs
@@ -34,7 +34,7 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers.ReflectedGenHandlers
             var parameterGens = constructor
                 .GetParameters()
                 .Select(parameter => innerHandler
-                    .CreateGen(parameter.ParameterType, context.Next(parameter.Name ?? "<unknown>", parameter.ParameterType)) // TODO: Indicate it's a ctor param in the path
+                    .CreateNamedGen(parameter.ParameterType, parameter.Name!, context)
                     .Cast<object>());
 
             return Gen


### PR DESCRIPTION
This is useful for snapshotting objects from generators that have been created through the reflection API e.g. `Gen.Create<MyType>()`, or any input to a property defined with the Xunit-integrated `[Property]` attribute.

The reflection API works by traversing through an object graph, and recursively generating members. Each member generated consumes some randomness which affects how the following members are generated. If you insert a member, or you change the way in which a value is generated from a member, the random seed for the remaining members will be offset (and thus the value most likely dramatically changed).

This change makes it so the seed is explicitly reset at every property, and it is derived from:
- The original seed
- The path of the member e.g. $.Property.NestedProperty

So long as the seed doesn't change, the path doesn't change, and the generator conventions don't change, the property value won't change.

Using generated values as inputs into your snapshot tests is now viable, and you don't need to persist any intermediate fixtures for your inputs.
