### PR TITLE
🌍 #349 Improve integer generator run performance by 30-35%

### DIFF
--- a/src/GalaxyCheck.Benchmarks/Program.cs
+++ b/src/GalaxyCheck.Benchmarks/Program.cs
@@ -9,6 +9,8 @@ namespace GalaxyCheck.Benchmarks
             BenchmarkRunner.Run<RngBenchmark>();
             BenchmarkRunner.Run<ReflectedGenBenchmark>();
             BenchmarkRunner.Run<ListGenBenchmark>();
+            BenchmarkRunner.Run<SelectManyGenBenchmark>();
+            BenchmarkRunner.Run<SelectGenBenchmark>();
         }
     }
 }

--- a/src/GalaxyCheck.Benchmarks/SelectGenBenchmark.cs
+++ b/src/GalaxyCheck.Benchmarks/SelectGenBenchmark.cs
@@ -1,0 +1,45 @@
+﻿using BenchmarkDotNet.Attributes;
+using GalaxyCheck.Gens.Parameters;
+using System.Linq;
+
+namespace GalaxyCheck.Benchmarks
+{
+    [SimpleJob]
+    public class SelectGenBenchmark
+    {
+
+        private const int OperationsPerInvoke = 50000;
+
+        private int _seed = 0;
+
+        [IterationCleanup]
+        public void IncrementRng()
+        {
+            _seed += 1;
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void SelectGen()
+        {
+            var gen = Gen.Int32().Select(x => x);
+
+            var enumerable = gen.Advanced
+                .Run(GenParameters.Create(seed: _seed, size: 100))
+                .Take(OperationsPerInvoke);
+
+            foreach (var _ in enumerable) { }
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void SelectGenBaseline()
+        {
+            var gen = Gen.Int32();
+
+            var enumerable = gen.Advanced
+                .Run(GenParameters.Create(seed: _seed, size: 100))
+                .Take(OperationsPerInvoke);
+
+            foreach (var _ in enumerable) { }
+        }
+    }
+}

--- a/src/GalaxyCheck.Benchmarks/SelectManyGenBenchmark.cs
+++ b/src/GalaxyCheck.Benchmarks/SelectManyGenBenchmark.cs
@@ -1,0 +1,48 @@
+﻿using BenchmarkDotNet.Attributes;
+using GalaxyCheck.Gens.Parameters;
+using System.Linq;
+
+namespace GalaxyCheck.Benchmarks
+{
+    [SimpleJob]
+    public class SelectManyGenBenchmark
+    {
+
+        private const int OperationsPerInvoke = 10000;
+
+        private int _seed = 0;
+
+        [IterationCleanup]
+        public void IncrementRng()
+        {
+            _seed += 1;
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void SelectManyGen()
+        {
+            var gen =
+                from x in Gen.Int32()
+                from y in Gen.Int32()
+                select (x, y);
+
+            var enumerable = gen.Advanced
+                .Run(GenParameters.Create(seed: _seed, size: 100))
+                .Take(OperationsPerInvoke);
+
+            foreach (var _ in enumerable) { }
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void SelectManyGenBaseline()
+        {
+            var gen = Gen.Int32();
+
+            var enumerable = gen.Advanced
+                .Run(GenParameters.Create(seed: _seed, size: 100))
+                .Take(OperationsPerInvoke * 2);
+
+            foreach (var _ in enumerable) { }
+        }
+    }
+}

--- a/src/GalaxyCheck/Gens/Internal/Iterations/GenIterationFactory.cs
+++ b/src/GalaxyCheck/Gens/Internal/Iterations/GenIterationFactory.cs
@@ -107,7 +107,7 @@ namespace GalaxyCheck.Gens.Internal.Iterations
         {
             var instanceData = GenData<T>.InstanceData(
                 exampleSpace,
-                Enumerable.Concat(lastExampleSpaceHistory, new[] { exampleSpace }));
+                lastExampleSpaceHistory.Append(exampleSpace));
 
             return new GenIteration<T>(replayParameters, nextParameters, instanceData);
         }


### PR DESCRIPTION
We cache the work when we create an int gen, but inside a SelectMany, we're creating a new gen every iteration.

Lazily calculate the bounds ranges.

Before:

```
|                Method |      Mean |     Error |    StdDev |
|---------------------- |----------:|----------:|----------:|
|         SelectManyGen | 31.904 us | 0.5425 us | 0.8120 us |
| SelectManyGenBaseline |  9.950 us | 0.1692 us | 0.1500 us |
```

After:

```
|                Method |      Mean |     Error |    StdDev |
|---------------------- |----------:|----------:|----------:|
|         SelectManyGen | 20.077 us | 0.3833 us | 0.4101 us |
| SelectManyGenBaseline |  9.833 us | 0.1924 us | 0.2363 us |
```
