### PR TITLE
🌍 #361 Generator stability V2

### DIFF
--- a/src/GalaxyCheck.Benchmarks/ListGenBenchmark.cs
+++ b/src/GalaxyCheck.Benchmarks/ListGenBenchmark.cs
@@ -28,7 +28,7 @@ namespace GalaxyCheck.Benchmarks
             var gen = Gen.Int32().ListOf().WithCountLessThanEqual(size);
 
             var enumerable = gen.Advanced
-                .Run(GenParameters.Create(seed: _seed, size: 100))
+                .Run(GenParameters.Parse(seed: _seed, size: 100))
                 .Take(OperationsPerInvoke);
 
             foreach (var _ in enumerable) { }

--- a/src/GalaxyCheck.Benchmarks/SelectGenBenchmark.cs
+++ b/src/GalaxyCheck.Benchmarks/SelectGenBenchmark.cs
@@ -24,7 +24,7 @@ namespace GalaxyCheck.Benchmarks
             var gen = Gen.Int32().Select(x => x);
 
             var enumerable = gen.Advanced
-                .Run(GenParameters.Create(seed: _seed, size: 100))
+                .Run(GenParameters.Parse(seed: _seed, size: 100))
                 .Take(OperationsPerInvoke);
 
             foreach (var _ in enumerable) { }
@@ -36,7 +36,7 @@ namespace GalaxyCheck.Benchmarks
             var gen = Gen.Int32();
 
             var enumerable = gen.Advanced
-                .Run(GenParameters.Create(seed: _seed, size: 100))
+                .Run(GenParameters.Parse(seed: _seed, size: 100))
                 .Take(OperationsPerInvoke);
 
             foreach (var _ in enumerable) { }

--- a/src/GalaxyCheck.Benchmarks/SelectManyGenBenchmark.cs
+++ b/src/GalaxyCheck.Benchmarks/SelectManyGenBenchmark.cs
@@ -27,7 +27,7 @@ namespace GalaxyCheck.Benchmarks
                 select (x, y);
 
             var enumerable = gen.Advanced
-                .Run(GenParameters.Create(seed: _seed, size: 100))
+                .Run(GenParameters.Parse(seed: _seed, size: 100))
                 .Take(OperationsPerInvoke);
 
             foreach (var _ in enumerable) { }
@@ -39,7 +39,7 @@ namespace GalaxyCheck.Benchmarks
             var gen = Gen.Int32();
 
             var enumerable = gen.Advanced
-                .Run(GenParameters.Create(seed: _seed, size: 100))
+                .Run(GenParameters.Parse(seed: _seed, size: 100))
                 .Take(OperationsPerInvoke * 2);
 
             foreach (var _ in enumerable) { }

--- a/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutStability.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutStability.cs
@@ -1,0 +1,76 @@
+﻿using FluentAssertions;
+using GalaxyCheck;
+using static Tests.V2.DomainGenAttributes;
+
+namespace Tests.V2.GenTests.ReflectedGenTests
+{
+    public class AboutStability
+    {
+        private class ClassWithPropertiesV1
+        {
+            public int Property { get; set; }
+        }
+
+        private class ClassWithPropertiesV2
+        {
+            public int A_Property { get; set; }
+            public int Property { get; set; }
+            public int Z_Property { get; set; }
+        }
+
+        [NebulaCheck.Property]
+        public void AddingNewPropertiesDoesNotChangeHowExistingPropertiesAreGenerated([Seed] int seed, [Size] int size)
+        {
+            var gen0 = Gen.Create<ClassWithPropertiesV1>().Advanced.SetRngWaypoint();
+            var sample0 = gen0.SampleOne(seed: seed, size: size);
+
+            var gen1 = Gen.Create<ClassWithPropertiesV2>().Advanced.SetRngWaypoint();
+            var sample1 = gen1.SampleOne(seed: seed, size: size);
+
+            sample1.Property.Should().Be(sample0.Property);
+        }
+
+        private class ClassWithFieldsV1
+        {
+            public int Field = 0;
+        }
+
+        private class ClassWithFieldsV2
+        {
+            public int A_Field = 0;
+            public int Field = 0;
+            public int Z_Field = 0;
+        }
+
+        [NebulaCheck.Property]
+        public void AddingNewFieldsDoesNotChangeHowExistingFieldsAreGenerated([Seed] int seed, [Size] int size)
+        {
+            var gen0 = Gen.Create<ClassWithFieldsV1>().Advanced.SetRngWaypoint();
+            var sample0 = gen0.SampleOne(seed: seed, size: size);
+
+            var gen1 = Gen.Create<ClassWithFieldsV2>().Advanced.SetRngWaypoint();
+            var sample1 = gen1.SampleOne(seed: seed, size: size);
+
+            sample1.Field.Should().Be(sample0.Field);
+        }
+
+        private record RecordV1(int Property);
+
+        private record RecordV2(
+            int A_Property,
+            int Property,
+            int Z_Property);
+
+        [NebulaCheck.Property]
+        public void AddingNewPropertiesToStandardRecordConstructorDoesNotChangeHowExistingPropertiesAreGenerated([Seed] int seed, [Size] int size)
+        {
+            var gen0 = Gen.Create<RecordV1>().Advanced.SetRngWaypoint();
+            var sample0 = gen0.SampleOne(seed: seed, size: size);
+
+            var gen1 = Gen.Create<RecordV2>().Advanced.SetRngWaypoint();
+            var sample1 = gen1.SampleOne(seed: seed, size: size);
+
+            sample1.Property.Should().Be(sample0.Property);
+        }
+    }
+}

--- a/src/GalaxyCheck.Tests/ImplementationTests/ReplayEncodingTests/AboutReplayEncoding.cs
+++ b/src/GalaxyCheck.Tests/ImplementationTests/ReplayEncodingTests/AboutReplayEncoding.cs
@@ -12,36 +12,36 @@ namespace Tests.V2.ImplementationTests.ReplayEncodingTests
 {
     public class AboutReplayEncoding
     {
-        public static TheoryData<int, int, IEnumerable<int>, string> Data =>
-            new TheoryData<int, int, IEnumerable<int>, string>
+        public static TheoryData<int, int, int?, IEnumerable<int>, string> Data =>
+            new TheoryData<int, int, int?, IEnumerable<int>, string>
             {
                 {
-                    0, 0, new [] { 0 },
+                    0, 0, null, new [] { 0 },
                     "H4sIAAAAAAAACjPQM9AzAACGS1suBQAAAA=="
                 },
                 {
-                    0, 0, new [] { 0, 0, 0, 0, 0, 0 },
+                    0, 0, null, new [] { 0, 0, 0, 0, 0, 0 },
                     "H4sIAAAAAAAACjPQM9AzsIJDALKWW5IPAAAA"
                 },
                 {
-                    0, 0, Enumerable.Range(0, 10).Select(_ => 0),
+                    0, 0, null, Enumerable.Range(0, 10).Select(_ => 0),
                     "H4sIAAAAAAAACjPQM9AzsMKAANukRbAXAAAA"
                 },
                 {
-                    0, 0, Enumerable.Range(0, 100).Select(_ => 0),
+                    0, 0, null, Enumerable.Range(0, 100).Select(_ => 0),
                     "H4sIAAAAAAAACjPQM9AzsBoWEAC35Wk5ywAAAA=="
                 },
                 {
-                    int.MaxValue, 100, Enumerable.Range(0, 100),
-                    "H4sIAAAAAAAACg2Qxw3AQBACO7I2sGn6L8z3RQIGwjXabM3nZp/hBIkommE5/ImOB5648MIbH3zxI4x4niCSEFFEE0MscaSRTr7IJEUW2eSQSx4y5CjQaxQq1GjQoqOMciqopB5QUU0NtdTRRjsddNKiH2/TQy99jDHOBJOMmGLenGGWOdZYZ4NNVmyxzb61yx5nnHPBJSeuuOaGe2fcD7ogWEAwAQAA"
+                    int.MaxValue, 100, int.MaxValue, Enumerable.Range(0, 100),
+                    "H4sIAAAAAAAACj2Qxw0EQQzDOlo4yIn9F3bzuq8ABSpco83WfG72GU6QiKIZlsOf6HjgiQsvvPHBFz/CiOcJIgkRRTQxxBJHGunki0xSZJFNDrnkIUOOAr1GoUKNBi06yiingkrqDSqqqaGWOtpop4NOWvTb2/TQSx9jjDPBJCOmmIczzDLHGutssMmKLbbZR7vsccY5F1xy4oprbrh3xn3xP+wHz39ZWzsBAAA="
                 },
             };
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void Examples(int seed, int size, IEnumerable<int> exampleSpacePath, string expectedEncoding)
+        public void Examples(int seed, int size, int? seedWaypoint, IEnumerable<int> exampleSpacePath, string expectedEncoding)
         {
-            var replay = CreateReplay(seed, size, exampleSpacePath);
+            var replay = CreateReplay(seed, size, seedWaypoint, exampleSpacePath);
 
             // TODO: Cross-platform consistent replay encoding
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -56,17 +56,18 @@ namespace Tests.V2.ImplementationTests.ReplayEncodingTests
         public IGen<Test> EncodeDecodeIsAnIsomorphism() =>
             from seed in Gen.Int32()
             from size in Gen.Int32().Between(0, 100)
+            from seedWaypoint in Gen.Choose(Gen.Int32().Cast<int?>(), Gen.Constant<int?>(null))
             from exampleSpacePath in Gen.Int32().ListOf()
             select Property.ForThese(() =>
             {
-                var replay0 = CreateReplay(seed, size, exampleSpacePath);
+                var replay0 = CreateReplay(seed, size, seedWaypoint, exampleSpacePath);
                 var replay1 = ReplayEncoding.Decode(ReplayEncoding.Encode(replay0));
 
                 replay1.GenParameters.Should().Be(replay0.GenParameters);
                 replay1.ExampleSpacePath.Should().BeEquivalentTo(replay0.ExampleSpacePath);
             });
 
-        private static Replay CreateReplay(int seed, int size, IEnumerable<int> exampleSpacePath) =>
-            new Replay(GenParameters.Create(Rng.Create(seed), new Size(size)), exampleSpacePath);
+        private static Replay CreateReplay(int seed, int size, int? seedWaypoint, IEnumerable<int> exampleSpacePath) =>
+            new Replay(new GenParameters(Rng.Create(seed), new Size(size), seedWaypoint == null ? null : Rng.Create(seedWaypoint.Value)), exampleSpacePath);
     }
 }

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/AboutReplay.cs
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/AboutReplay.cs
@@ -90,7 +90,7 @@ namespace Tests.V2.RunnerTests.CheckTests
         private static Replay CreateReplay(int replaySeed, int replaySize, IEnumerable<int> replayPath)
         {
             return new Replay(
-                GalaxyCheck.Gens.Parameters.GenParameters.Create(replaySeed, replaySize),
+                GalaxyCheck.Gens.Parameters.GenParameters.Parse(replaySeed, replaySize),
                 replayPath);
         }
     }

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtLargerSizes_Iterations=1.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtLargerSizes_Iterations=1.snap
@@ -14,7 +14,8 @@
       },
       "Size": {
         "Value": 100
-      }
+      },
+      "RngWaypoint": null
     },
     "ReplayPath": [],
     "Replay": "",
@@ -32,7 +33,8 @@
     },
     "Size": {
       "Value": 100
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -42,7 +44,8 @@
     },
     "Size": {
       "Value": 100
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": true,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtLargerSizes_Iterations=100.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtLargerSizes_Iterations=100.snap
@@ -14,7 +14,8 @@
       },
       "Size": {
         "Value": 50
-      }
+      },
+      "RngWaypoint": null
     },
     "ReplayPath": [],
     "Replay": "",
@@ -32,7 +33,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -42,7 +44,8 @@
     },
     "Size": {
       "Value": 50
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "FoundTheoreticalSmallestCounterexample",
   "Falsified": true,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtLargerSizes_Iterations=2.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtLargerSizes_Iterations=2.snap
@@ -14,7 +14,8 @@
       },
       "Size": {
         "Value": 100
-      }
+      },
+      "RngWaypoint": null
     },
     "ReplayPath": [],
     "Replay": "",
@@ -32,7 +33,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -42,7 +44,8 @@
     },
     "Size": {
       "Value": 100
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": true,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtLargerSizes_Iterations=50.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtLargerSizes_Iterations=50.snap
@@ -14,7 +14,8 @@
       },
       "Size": {
         "Value": 51
-      }
+      },
+      "RngWaypoint": null
     },
     "ReplayPath": [],
     "Replay": "",
@@ -32,7 +33,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -42,7 +44,8 @@
     },
     "Size": {
       "Value": 51
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "FoundTheoreticalSmallestCounterexample",
   "Falsified": true,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtSmallerSizes_Iterations=1.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtSmallerSizes_Iterations=1.snap
@@ -12,7 +12,8 @@
     },
     "Size": {
       "Value": 100
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -22,7 +23,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": false,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtSmallerSizes_Iterations=100.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtSmallerSizes_Iterations=100.snap
@@ -14,7 +14,8 @@
       },
       "Size": {
         "Value": 0
-      }
+      },
+      "RngWaypoint": null
     },
     "ReplayPath": [],
     "Replay": "",
@@ -32,7 +33,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -42,7 +44,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "FoundTheoreticalSmallestCounterexample",
   "Falsified": true,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtSmallerSizes_Iterations=2.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtSmallerSizes_Iterations=2.snap
@@ -14,7 +14,8 @@
       },
       "Size": {
         "Value": 0
-      }
+      },
+      "RngWaypoint": null
     },
     "ReplayPath": [],
     "Replay": "",
@@ -32,7 +33,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -42,7 +44,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "FoundTheoreticalSmallestCounterexample",
   "Falsified": true,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtSmallerSizes_Iterations=50.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Falsifiable_AtSmallerSizes_Iterations=50.snap
@@ -14,7 +14,8 @@
       },
       "Size": {
         "Value": 0
-      }
+      },
+      "RngWaypoint": null
     },
     "ReplayPath": [],
     "Replay": "",
@@ -32,7 +33,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -42,7 +44,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "FoundTheoreticalSmallestCounterexample",
   "Falsified": true,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Filtered_Iterations=1.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Filtered_Iterations=1.snap
@@ -12,7 +12,8 @@
     },
     "Size": {
       "Value": 100
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -22,7 +23,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": false,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Filtered_Iterations=100.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Filtered_Iterations=100.snap
@@ -12,7 +12,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -22,7 +23,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": false,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Filtered_Iterations=2.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Filtered_Iterations=2.snap
@@ -12,7 +12,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -22,7 +23,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": false,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Filtered_Iterations=50.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Filtered_Iterations=50.snap
@@ -12,7 +12,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -22,7 +23,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": false,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Iterations=1.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Iterations=1.snap
@@ -12,7 +12,8 @@
     },
     "Size": {
       "Value": 100
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -22,7 +23,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": false,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Iterations=100.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Iterations=100.snap
@@ -12,7 +12,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -22,7 +23,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": false,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Iterations=2.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Iterations=2.snap
@@ -12,7 +12,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -22,7 +23,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": false,

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Iterations=50.snap
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/__snapshots__/Snapshots.Unfalsifiable_Iterations=50.snap
@@ -12,7 +12,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "NextParameters": {
     "Rng": {
@@ -22,7 +23,8 @@
     },
     "Size": {
       "Value": 0
-    }
+    },
+    "RngWaypoint": null
   },
   "TerminationReason": "ReachedMaximumIterations",
   "Falsified": false,

--- a/src/GalaxyCheck/Gens/CreateGen.cs
+++ b/src/GalaxyCheck/Gens/CreateGen.cs
@@ -6,6 +6,7 @@ using GalaxyCheck.Gens.Iterations.Generic;
 using GalaxyCheck.Gens.Parameters;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace GalaxyCheck
 {
@@ -17,7 +18,7 @@ namespace GalaxyCheck
         /// with minimal configuration through reflection.
         /// </summary>
         /// <returns>A generator for the given type.</returns>
-        public static IReflectedGen<T> Create<T>() where T : notnull => Factory().Create<T>();
+        public static IReflectedGen<T> Create<T>(NullabilityInfo? nullabilityInfo = null) where T : notnull => Factory().Create<T>(nullabilityInfo);
 
         /// <summary>
         /// Generates instances by the given function. Instances will not shrink by default, to enable shrinking on the

--- a/src/GalaxyCheck/Gens/InfiniteGen.cs
+++ b/src/GalaxyCheck/Gens/InfiniteGen.cs
@@ -74,11 +74,11 @@ namespace GalaxyCheck.Gens
                 var nextRng = initialRng.Next();
                 var forkedRng = initialRng.Fork();
 
-                var exampleSpace = CreateInfiniteEnumerableSpace(_elementGen, parameters.With(rng: forkedRng), _iterationLimit);
+                var exampleSpace = CreateInfiniteEnumerableSpace(_elementGen, parameters with { Rng = forkedRng }, _iterationLimit);
 
                 yield return GenIterationFactory.Instance(
-                    parameters.With(rng: initialRng),
-                    parameters.With(rng: nextRng),
+                    parameters with { Rng = initialRng },
+                    parameters with { Rng = nextRng },
                     exampleSpace);
 
                 rng = rng.Next();

--- a/src/GalaxyCheck/Gens/Parameters/GenParameters.cs
+++ b/src/GalaxyCheck/Gens/Parameters/GenParameters.cs
@@ -1,45 +1,38 @@
 ﻿namespace GalaxyCheck.Gens.Parameters
 {
-    public record GenParameters
+    public record GenParameters(
+        IRng Rng,
+        Size Size,
+        IRng? RngWaypoint)
     {
-        public IRng Rng { get; init; }
-
-        public Size Size { get; init; }
-
-        private GenParameters(IRng rng, Size size)
+        public static GenParameters Parse(int seed, int size, int? seedWaypoint = null)
         {
-            Rng = rng;
-            Size = size;
-        }
-
-        public static GenParameters Create(int seed, int size)
-        {
-            return new GenParameters(Internal.Rng.Create(seed), new Size(size));
-        }
-
-        public static GenParameters Create(int size)
-        {
-            return new GenParameters(Internal.Rng.Spawn(), new Size(size));
+            return new GenParameters(
+                Internal.Rng.Create(seed),
+                new Size(size),
+                seedWaypoint == null ? null : Internal.Rng.Create(seedWaypoint.Value));
         }
 
         internal static GenParameters Create(IRng rng, Size size)
         {
-            return new GenParameters(rng, size);
+            return new GenParameters(rng, size, null);
         }
 
-        internal static GenParameters Create(Size size)
+        internal static GenParameters CreateRandom(Size size)
         {
-            return new GenParameters(Internal.Rng.Spawn(), size);
+            return new GenParameters(Internal.Rng.Spawn(), size, null);
         }
-
-        public GenParameters With(
-            IRng? rng = null,
-            Size? size = null) =>
-                new GenParameters(rng ?? Rng, size ?? Size);
 
         public override string ToString()
         {
-            return $"Rng={Rng},Size={Size}";
+            var result = $"Rng={Rng},Size={Size}";
+
+            if (RngWaypoint != null)
+            {
+                result += $",RngWaypoing={RngWaypoint}";
+            }
+
+            return result;
         }
     }
 }

--- a/src/GalaxyCheck/Gens/Parameters/IRng.cs
+++ b/src/GalaxyCheck/Gens/Parameters/IRng.cs
@@ -37,6 +37,14 @@
         IRng Fork();
 
         /// <summary>
+        /// Creates a new RNG with the given seed. This will affect how the next value is generated, but not disrupt
+        /// any other properties of the RNG.
+        /// </summary>
+        /// <param name="seed">The next seed to use.</param>
+        /// <returns></returns>
+        IRng Influence(int seed);
+
+        /// <summary>
         /// Generates a random 64-bit integer, based off of the seed, and some given boundaries. This is a pure
         /// function and will always return the same integer, given the same boundaries.
         /// </summary>

--- a/src/GalaxyCheck/Gens/Parameters/Internal/Rng.cs
+++ b/src/GalaxyCheck/Gens/Parameters/Internal/Rng.cs
@@ -36,6 +36,16 @@ namespace GalaxyCheck.Gens.Parameters.Internal
 
         public IRng Fork() => Create((Family + 1) * -1521134295 + Order);
 
+        public IRng Influence(int seed)
+        {
+            int nextSeed;
+            unchecked
+            {
+                nextSeed = Seed + seed;
+            }
+            return new Rng(Family, nextSeed, Order);
+        }
+
         public long Value(long min, long max)
         {
             if (min > max) throw new ArgumentOutOfRangeException(nameof(min), "'min' cannot be greater than 'max'");

--- a/src/GalaxyCheck/Gens/ParametersGen.cs
+++ b/src/GalaxyCheck/Gens/ParametersGen.cs
@@ -86,8 +86,8 @@ namespace GalaxyCheck.Gens
                     .GetMethod(nameof(IGenFactory.Create))!
                     .MakeGenericMethod(parameterInfo.ParameterType);
 
-                var nullabilityInfoCtx = new NullabilityInfoContext();
-                var nullabilityInfo = nullabilityInfoCtx.Create(parameterInfo);
+                var nullabilityInfoContext = new NullabilityInfoContext();
+                var nullabilityInfo = nullabilityInfoContext.Create(parameterInfo);
 
                 var gen = (IGen)createGenMethodInfo.Invoke(configuredGenFactory, new object[] { nullabilityInfo })!;
 

--- a/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlerContext.cs
+++ b/src/GalaxyCheck/Gens/ReflectedGenHelpers/ReflectedGenHandlerContext.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Reflection;
+using System.Text;
 
 namespace GalaxyCheck.Gens.ReflectedGenHelpers
 {
@@ -21,5 +23,18 @@ namespace GalaxyCheck.Gens.ReflectedGenHelpers
         };
 
         public string MemberPath => string.Join(".", Members);
+    }
+
+    internal static class ReflectedGenHandlerContextExtensions
+    {
+        public static int CalculateStableSeed(this ReflectedGenHandlerContext context) => Encoding.Unicode
+            .GetBytes(context.MemberPath)
+            .Aggregate(0, (acc, curr) =>
+            {
+                unchecked
+                {
+                    return acc + curr;
+                }
+            });
     }
 }

--- a/src/GalaxyCheck/Gens/RngWaypointGen.cs
+++ b/src/GalaxyCheck/Gens/RngWaypointGen.cs
@@ -1,0 +1,37 @@
+﻿using GalaxyCheck.Gens.Internal;
+using GalaxyCheck.Gens.Parameters;
+using System;
+
+namespace GalaxyCheck
+{
+    public static partial class Gen
+    {
+        /// <summary>
+        /// Sets the RNG waypoint, that can be used be a later evaluated generator. Useful if you want to control
+        /// randomness somewhat, you can use the waypoint as a reference in your generator, independent of what
+        /// randomness was consumed between the waypoint being set, and your generator being evaluated,
+        /// <see cref="ReferenceRngWaypoint{T}(IGenAdvanced{T}, Func{IRng, IRng})"/>.
+        /// </summary>
+        /// <param name="gen">The generator to set the waypoint on.</param>
+        /// <returns>A new generator, that passes the waypoint through to the given generator.</returns>
+        public static IGen<T> SetRngWaypoint<T>(this IGenAdvanced<T> gen) =>
+            new FunctionalGen<T>(parameters => gen.Run(parameters with { RngWaypoint = parameters.Rng }));
+
+        /// <summary>
+        /// Allows a generator to reference a previously created RNG waypoint, so generation can be controlled.
+        /// If a waypoint was previously set, it will be passed to the <paramref name="alignRngToWaypoint"/> function,
+        /// from which you can create a new <see cref="IRng"/>. Then, the generator will be ran with that RNG. If a
+        /// waypoint was not previously set, it will run the generator as normal.
+        /// </summary>
+        /// <param name="gen">The underlying generator to run, with respect to the waypoint RNG.</param>
+        /// <param name="alignRngToWaypoint">A function used to some new randomness, for which you can control.</param>
+        /// <returns>A new generator, which is created from the given generator, and an understanding of the RNG
+        /// waypoint options.</returns>
+        public static IGen<T> ReferenceRngWaypoint<T>(this IGenAdvanced<T> gen, Func<IRng, IRng> alignRngToWaypoint) =>
+            new FunctionalGen<T>(parameters =>
+            {
+                var rng = parameters.RngWaypoint == null ? parameters.Rng : alignRngToWaypoint(parameters.RngWaypoint);
+                return gen.Run(parameters with { Rng = rng });
+            });
+    }
+}

--- a/src/GalaxyCheck/Operators/SelectMany.cs
+++ b/src/GalaxyCheck/Operators/SelectMany.cs
@@ -103,7 +103,7 @@ namespace GalaxyCheck
                         var innerStream = BindExampleSpace(
                             instance.ExampleSpace,
                             selector,
-                            instance.ReplayParameters.With(rng: instance.NextParameters.Rng));
+                            instance.ReplayParameters with { Rng = instance.NextParameters.Rng });
 
                         foreach (var innerIteration in innerStream)
                         {

--- a/src/GalaxyCheck/Operators/Where.cs
+++ b/src/GalaxyCheck/Operators/Where.cs
@@ -51,7 +51,7 @@ namespace GalaxyCheck
                         {
                             var resizedIteration = GenIterationFactory.Discard<T>(
                                 iteration.ReplayParameters,
-                                iteration.NextParameters.With(size: iteration.NextParameters.Size.BigIncrement()),
+                                iteration.NextParameters with { Size = iteration.NextParameters.Size.BigIncrement() },
                                 iteration.Data.Discard!.ExampleSpace);
 
                             return (iteration: resizedIteration, consecutiveDiscardCount);

--- a/src/GalaxyCheck/Runners/Check.cs
+++ b/src/GalaxyCheck/Runners/Check.cs
@@ -27,7 +27,7 @@ namespace GalaxyCheck
             var (initialSize, resizeStrategy) = SizingAspects<T>.Resolve(size == null ? null : new Size(size.Value), resolvedIterations);
 
             var initialParameters = seed == null
-                ? GenParameters.Create(initialSize)
+                ? GenParameters.CreateRandom(initialSize)
                 : GenParameters.Create(Rng.Create(seed.Value), initialSize);
 
             var initialContext = new Automata.CheckStateContext<T>(
@@ -72,7 +72,7 @@ namespace GalaxyCheck
             var (initialSize, resizeStrategy) = SizingAspectsAsync<T>.Resolve(size == null ? null : new Size(size.Value), resolvedIterations);
 
             var initialParameters = seed == null
-                ? GenParameters.Create(initialSize)
+                ? GenParameters.CreateRandom(initialSize)
                 : GenParameters.Create(Rng.Create(seed.Value), initialSize);
 
             var initialContext = new AsyncAutomata.CheckStateContext<T>(

--- a/src/GalaxyCheck/Runners/Replaying/ReplayEncoding.cs
+++ b/src/GalaxyCheck/Runners/Replaying/ReplayEncoding.cs
@@ -43,14 +43,19 @@ namespace GalaxyCheck.Runners.Replaying
 
         public static string Encode(Replay replay)
         {
-            var str = string.Join(".", new[]
+            var encodingComponents = new List<string>()
             {
                 EncodeInt(replay.GenParameters.Rng.Seed),
                 EncodeInt(replay.GenParameters.Size.Value),
                 EncodeExampleSpacePath(replay.ExampleSpacePath)
-            });
+            };
 
-            return CompressString(str);
+            if (replay.GenParameters.RngWaypoint != null)
+            {
+                encodingComponents.Add(EncodeInt(replay.GenParameters.RngWaypoint.Seed));
+            }
+
+            return CompressString(string.Join(".", encodingComponents));
         }
 
         public static Replay Decode(string str)
@@ -63,8 +68,10 @@ namespace GalaxyCheck.Runners.Replaying
             var size = DecodeInt(components[1]);
             var exampleSpacePath = DecodeExampleSpacePath(components[2]);
 
+            int? seedWapoint = components.Count() > 3 ? DecodeInt(components[3]) : null;
+
             return new Replay(
-                GenParameters.Create(seed, size),
+                GenParameters.Parse(seed, size, seedWapoint),
                 exampleSpacePath);
         }
     }


### PR DESCRIPTION
This was initially trialled in #337, but was rolled back as it adversely affected randomness.

Second attempt is much cleaner and tidier, doesn't affect randomness, and is opt-in (a snaphotting impl would choose to turn it on).

You can call `SetRngWaypoint` on your root generator, then any generators that it's comprised of can generate stable seeds for themselves using `ReferenceRngWaypoint`.
