### PR TITLE
🌍 #376 Tidy up: remove unnecessary diagnostics

### DIFF
--- a/src/GalaxyCheck.Tests/AssertionExceptions.cs
+++ b/src/GalaxyCheck.Tests/AssertionExceptions.cs
@@ -1,0 +1,14 @@
+using FluentAssertions.Specialized;
+
+namespace Tests.V2
+{
+    public static class AssertionExceptions
+    {
+        public static ExceptionAssertions<GalaxyCheck.Exceptions.GenErrorException> WithGenErrorMessage(
+            this ExceptionAssertions<GalaxyCheck.Exceptions.GenErrorException> assertions,
+            string messageBody)
+        {
+            return assertions.WithMessage("*" + messageBody);
+        }
+    }
+}

--- a/src/GalaxyCheck.Tests/GenAssert.cs
+++ b/src/GalaxyCheck.Tests/GenAssert.cs
@@ -54,7 +54,7 @@ namespace Tests.V2
             {
                 test.Should()
                     .Throw<Exceptions.GenErrorException>()
-                    .WithMessage(expectedMessage);
+                    .WithGenErrorMessage(expectedMessage);
             }
         }
     }

--- a/src/GalaxyCheck.Tests/GenTests/ByteGenTests/AboutExtensions.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ByteGenTests/AboutExtensions.cs
@@ -66,7 +66,7 @@ namespace Tests.V2.GenTests.ByteGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Byte().GreaterThan(255): Arithmetic operation resulted in an overflow.");
+                    .WithGenErrorMessage("Arithmetic operation resulted in an overflow.");
             });
 
         [Property]
@@ -91,13 +91,13 @@ namespace Tests.V2.GenTests.ByteGenTests
 
                 var gen = mockGen.Object.LessThan(byte.MinValue);
 
-                mockGen.Verify(gen => gen.LessThanEqual(It.IsAny<byte>()), Times.Never);
+                mockGen.Verify(gen0 => gen0.LessThanEqual(It.IsAny<byte>()), Times.Never);
 
                 Action action = () => gen.SampleOne(seed: seed, size: size);
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Byte().LessThan(0): Arithmetic operation resulted in an overflow.");
+                    .WithGenErrorMessage("Arithmetic operation resulted in an overflow.");
             });
 
         private static Mock<IIntGen<byte>> SetupMock()

--- a/src/GalaxyCheck.Tests/GenTests/ByteGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ByteGenTests/AboutValidation.cs
@@ -25,7 +25,7 @@ namespace Tests.V2.GenTests.ByteGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Byte: 'min' cannot be greater than 'max'");
+                    .WithGenErrorMessage("'min' cannot be greater than 'max'");
             });
 
         [Property]
@@ -42,7 +42,7 @@ namespace Tests.V2.GenTests.ByteGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Byte: 'origin' must be between 'min' and 'max'");
+                    .WithGenErrorMessage("'origin' must be between 'min' and 'max'");
             });
 
         [Property]
@@ -59,7 +59,7 @@ namespace Tests.V2.GenTests.ByteGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Byte: 'origin' must be between 'min' and 'max'");
+                    .WithGenErrorMessage("'origin' must be between 'min' and 'max'");
             });
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/CharGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/CharGenTests/AboutValidation.cs
@@ -26,7 +26,7 @@ namespace Tests.V2.GenTests.CharGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator CharGen: 'charType' was not a valid flag value");
+                    .WithGenErrorMessage("'charType' was not a valid flag value");
             });
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/ChooseGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ChooseGenTests/AboutValidation.cs
@@ -23,7 +23,7 @@ namespace Tests.V2.GenTests.ChooseGenTests
 
                     action.Should()
                         .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                        .WithMessage("Error while running generator ChooseGen: 'choices' must be non-empty");
+                        .WithGenErrorMessage("'choices' must be non-empty");
                 }
 
                 {
@@ -59,7 +59,7 @@ namespace Tests.V2.GenTests.ChooseGenTests
 
                     action.Should()
                         .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                        .WithMessage("Error while running generator ChooseGen: 'choices' must contain at least one generator with a weight greater than zero");
+                        .WithGenErrorMessage("'choices' must contain at least one generator with a weight greater than zero");
                 }
 
                 {
@@ -92,7 +92,7 @@ namespace Tests.V2.GenTests.ChooseGenTests
 
                     action.Should()
                         .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                        .WithMessage("Error while running generator ChooseGen: 'choices' must not contain a negatively weighted generator");
+                        .WithGenErrorMessage("'choices' must not contain a negatively weighted generator");
                 }
 
                 {

--- a/src/GalaxyCheck.Tests/GenTests/CreateGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/CreateGenTests/AboutValidation.cs
@@ -1,0 +1,7 @@
+namespace Tests.V2.GenTests.CreateGenTests
+{
+    public class AboutValidation
+    {
+        
+    }
+}

--- a/src/GalaxyCheck.Tests/GenTests/DateTimeGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/DateTimeGenTests/AboutValidation.cs
@@ -25,7 +25,7 @@ namespace Tests.V2.GenTests.DateTimeGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator DateTimeGen: 'from' datetime cannot be after 'until' datetime");
+                    .WithGenErrorMessage("'from' datetime cannot be after 'until' datetime");
             });
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/EnumGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/EnumGenTests/AboutValidation.cs
@@ -17,7 +17,7 @@ namespace Tests.V2.GenTests.EnumGenTests
 
             action.Should()
                 .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator EnumGen: Type 'System.Int32' is not an enum");
+                .WithGenErrorMessage("Type 'System.Int32' is not an enum");
         }
 
         [Property]
@@ -29,7 +29,7 @@ namespace Tests.V2.GenTests.EnumGenTests
 
             action.Should()
                 .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator EnumGen: Type 'System.Decimal' is not an enum");
+                .WithGenErrorMessage("Type 'System.Decimal' is not an enum");
         }
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/Int16GenTests/AboutExtensions.cs
+++ b/src/GalaxyCheck.Tests/GenTests/Int16GenTests/AboutExtensions.cs
@@ -66,7 +66,7 @@ namespace Tests.V2.GenTests.Int16GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int16().GreaterThan(32767): Arithmetic operation resulted in an overflow.");
+                    .WithGenErrorMessage("Arithmetic operation resulted in an overflow.");
             });
 
         [Property]
@@ -97,7 +97,7 @@ namespace Tests.V2.GenTests.Int16GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int16().LessThan(-32768): Arithmetic operation resulted in an overflow.");
+                    .WithGenErrorMessage("Arithmetic operation resulted in an overflow.");
             });
 
         private static Mock<IIntGen<short>> SetupMock()

--- a/src/GalaxyCheck.Tests/GenTests/Int16GenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/Int16GenTests/AboutValidation.cs
@@ -25,7 +25,7 @@ namespace Tests.V2.GenTests.Int16GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int16: 'min' cannot be greater than 'max'");
+                    .WithGenErrorMessage("'min' cannot be greater than 'max'");
             });
 
         [Property]
@@ -42,7 +42,7 @@ namespace Tests.V2.GenTests.Int16GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int16: 'origin' must be between 'min' and 'max'");
+                    .WithGenErrorMessage("'origin' must be between 'min' and 'max'");
             });
 
         [Property]
@@ -59,7 +59,7 @@ namespace Tests.V2.GenTests.Int16GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int16: 'origin' must be between 'min' and 'max'");
+                    .WithGenErrorMessage("'origin' must be between 'min' and 'max'");
             });
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/Int32GenTests/AboutExtensions.cs
+++ b/src/GalaxyCheck.Tests/GenTests/Int32GenTests/AboutExtensions.cs
@@ -61,13 +61,13 @@ namespace Tests.V2.GenTests.Int32GenTests
 
                 var gen = mockGen.Object.GreaterThan(int.MaxValue);
 
-                mockGen.Verify(gen => gen.GreaterThanEqual(It.IsAny<int>()), Times.Never);
+                mockGen.Verify(gen0 => gen0.GreaterThanEqual(It.IsAny<int>()), Times.Never);
 
                 Action action = () => gen.SampleOne(seed: seed, size: size);
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int32().GreaterThan(2147483647): Arithmetic operation resulted in an overflow.");
+                    .WithGenErrorMessage("Arithmetic operation resulted in an overflow.");
             });
 
         [Property]
@@ -98,7 +98,7 @@ namespace Tests.V2.GenTests.Int32GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int32().LessThan(-2147483648): Arithmetic operation resulted in an overflow.");
+                    .WithGenErrorMessage("Arithmetic operation resulted in an overflow.");
             });
 
         private static Mock<IIntGen<int>> SetupMock()

--- a/src/GalaxyCheck.Tests/GenTests/Int32GenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/Int32GenTests/AboutValidation.cs
@@ -25,7 +25,7 @@ namespace Tests.V2.GenTests.Int32GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int32: 'min' cannot be greater than 'max'");
+                    .WithGenErrorMessage("'min' cannot be greater than 'max'");
             });
 
         [Property]
@@ -42,7 +42,7 @@ namespace Tests.V2.GenTests.Int32GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int32: 'origin' must be between 'min' and 'max'");
+                    .WithGenErrorMessage("'origin' must be between 'min' and 'max'");
             });
 
         [Property]
@@ -59,7 +59,7 @@ namespace Tests.V2.GenTests.Int32GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int32: 'origin' must be between 'min' and 'max'");
+                    .WithGenErrorMessage("'origin' must be between 'min' and 'max'");
             });
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/Int64GenTests/AboutExtensions.cs
+++ b/src/GalaxyCheck.Tests/GenTests/Int64GenTests/AboutExtensions.cs
@@ -66,7 +66,7 @@ namespace Tests.V2.GenTests.Int64GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int64().GreaterThan(9223372036854775807): Arithmetic operation resulted in an overflow.");
+                    .WithGenErrorMessage("Arithmetic operation resulted in an overflow.");
             });
 
         [Property]
@@ -97,7 +97,7 @@ namespace Tests.V2.GenTests.Int64GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int64().LessThan(-9223372036854775808): Arithmetic operation resulted in an overflow.");
+                    .WithGenErrorMessage("Arithmetic operation resulted in an overflow.");
             });
 
         private static Mock<IIntGen<long>> SetupMock()

--- a/src/GalaxyCheck.Tests/GenTests/Int64GenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/Int64GenTests/AboutValidation.cs
@@ -25,7 +25,7 @@ namespace Tests.V2.GenTests.Int64GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int64: 'min' cannot be greater than 'max'");
+                    .WithGenErrorMessage("'min' cannot be greater than 'max'");
             });
 
         [Property]
@@ -42,7 +42,7 @@ namespace Tests.V2.GenTests.Int64GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int64: 'origin' must be between 'min' and 'max'");
+                    .WithGenErrorMessage("'origin' must be between 'min' and 'max'");
             });
 
         [Property]
@@ -59,7 +59,7 @@ namespace Tests.V2.GenTests.Int64GenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator Int64: 'origin' must be between 'min' and 'max'");
+                    .WithGenErrorMessage("'origin' must be between 'min' and 'max'");
             });
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/ListGenTests/AboutCountLimits.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ListGenTests/AboutCountLimits.cs
@@ -25,8 +25,8 @@ namespace Tests.V2.GenTests.ListGenTests
 
                     test.Should()
                         .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                        .WithMessage(
-                            "Error while running generator ListGen: Count limit exceeded. " +
+                        .WithGenErrorMessage(
+                            "Count limit exceeded. " +
                             "This is a built-in safety mechanism to prevent hanging tests. " +
                             "If generating a list with over 1000 elements was intended, relax this constraint by calling IListGen.DisableCountLimitUnsafe().");
                 }

--- a/src/GalaxyCheck.Tests/GenTests/ListGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ListGenTests/AboutValidation.cs
@@ -26,7 +26,7 @@ namespace Tests.V2.GenTests.ListGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ListGen: 'count' cannot be negative");
+                    .WithGenErrorMessage("'count' cannot be negative");
             });
 
         [Property]
@@ -43,7 +43,7 @@ namespace Tests.V2.GenTests.ListGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ListGen: 'minCount' cannot be negative");
+                    .WithGenErrorMessage("'minCount' cannot be negative");
             });
 
         [Property]
@@ -60,7 +60,7 @@ namespace Tests.V2.GenTests.ListGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ListGen: 'maxCount' cannot be negative");
+                    .WithGenErrorMessage("'maxCount' cannot be negative");
             });
 
         [Property]
@@ -78,7 +78,7 @@ namespace Tests.V2.GenTests.ListGenTests
 
                     action.Should()
                         .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                        .WithMessage("Error while running generator ListGen: 'minCount' cannot be greater than 'maxCount'");
+                        .WithGenErrorMessage("'minCount' cannot be greater than 'maxCount'");
                 }
 
                 ShouldError(GalaxyCheck.Gen.List(elementGen).WithCountGreaterThanEqual(minCount).WithCountLessThanEqual(maxCount));

--- a/src/GalaxyCheck.Tests/GenTests/ParameterGenTests/AboutCustomGens.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ParameterGenTests/AboutCustomGens.cs
@@ -28,7 +28,7 @@ namespace Tests.V2.GenTests.ParameterGenTests
                 GenAssert.Errors(
                     gen,
                     seed: seed,
-                    expectedMessage: $"Error while running generator ParametersGen: parameter index '{i}' of custom generator was not valid");
+                    expectedMessage: $"parameter index '{i}' of custom generator was not valid");
             }
 
             [Property]
@@ -44,7 +44,7 @@ namespace Tests.V2.GenTests.ParameterGenTests
                 GenAssert.Errors(
                     gen,
                     seed: seed,
-                    expectedMessage: $"Error while running generator ParametersGen: generator of type 'System.String' is not compatible with parameter of type 'System.Int32'");
+                    expectedMessage: $"generator of type 'System.String' is not compatible with parameter of type 'System.Int32'");
             }
 
             private static MethodInfo GetMethod(string name)

--- a/src/GalaxyCheck.Tests/GenTests/ParameterGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ParameterGenTests/AboutValidation.cs
@@ -29,7 +29,7 @@ namespace Tests.V2.GenTests.ParameterGenTests
 
             test.Should()
                 .Throw<Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator ParametersGen: unable to generate value for parameter 'x', type 'System.String' was not assignable to the type it was registered to, 'System.Int32'");
+                .WithGenErrorMessage("unable to generate value for parameter 'x', type 'System.String' was not assignable to the type it was registered to, 'System.Int32'");
         }
 
         private class AnotherStringGenAttribute : GenAttribute
@@ -48,7 +48,7 @@ namespace Tests.V2.GenTests.ParameterGenTests
 
             test.Should()
                 .Throw<Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator ParametersGen: unable to generate value for parameter 'x', multiple GenAttributes is unsupported");
+                .WithGenErrorMessage("unable to generate value for parameter 'x', multiple GenAttributes is unsupported");
         }
 
         private static MethodInfo GetMethod(string name)

--- a/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutConstructorSelection.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutConstructorSelection.cs
@@ -143,7 +143,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
             action.Should()
                 .Throw<Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator ReflectedGen: could not resolve type '*ClassWithNoPublicConstructor'");
+                .WithGenErrorMessage("could not resolve type '*ClassWithNoPublicConstructor'");
         }
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutExceptionsDuringObjectCreation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutExceptionsDuringObjectCreation.cs
@@ -31,7 +31,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ReflectedGen: 'System.Exception' was thrown while calling constructor with message 'Test exception'");
+                    .WithGenErrorMessage("'System.Exception' was thrown while calling constructor with message 'Test exception'");
             });
 
         private class ClassWithNonDefaultThrowingConstructor
@@ -54,7 +54,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ReflectedGen: 'System.Exception' was thrown while calling constructor with message 'Test exception'");
+                    .WithGenErrorMessage("'System.Exception' was thrown while calling constructor with message 'Test exception'");
             });
 
         private class ClassWithThrowingPropertySetter
@@ -87,7 +87,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ReflectedGen: 'System.Exception' was thrown while setting property with message 'Test exception'");
+                    .WithGenErrorMessage("'System.Exception' was thrown while setting property with message 'Test exception'");
             });
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutGeneratingDeepObjects.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutGeneratingDeepObjects.cs
@@ -56,7 +56,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ReflectedGen: detected circular reference on type '*ClassWithRecursiveProperty' at path '$.Property'");
+                    .WithGenErrorMessage("detected circular reference on type '*ClassWithRecursiveProperty' at path '$.Property'");
             });
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutOverridingMembers.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutOverridingMembers.cs
@@ -69,7 +69,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
             action.Should()
                 .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator ReflectedGen: attempted to override expression 'x => x.Property' on type 'Tests.V2.GenTests.ReflectedGenTests.AboutOverridingMembers+RecordWithOneProperty2', but overriding members for registered types is not currently supported (GitHub issue: https://github.com/nth-commit/GalaxyCheck/issues/346)");
+                .WithGenErrorMessage("attempted to override expression 'x => x.Property' on type 'Tests.V2.GenTests.ReflectedGenTests.AboutOverridingMembers+RecordWithOneProperty2', but overriding members for registered types is not currently supported (GitHub issue: https://github.com/nth-commit/GalaxyCheck/issues/346)");
         }
 
         private record RecordWithAMethod(object Property)
@@ -92,7 +92,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ReflectedGen: expression 'x => x.Method()' was invalid, an overriding expression may only contain member access");
+                    .WithGenErrorMessage("expression 'x => x.Method()' was invalid, an overriding expression may only contain member access");
             });
 
         [Property]
@@ -111,7 +111,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ReflectedGen: expression 'x => x.Method()' was invalid, an overriding expression may only contain member access");
+                    .WithGenErrorMessage("expression 'x => x.Method()' was invalid, an overriding expression may only contain member access");
             });
 
         private class ClassWithNonDefaultConstructor
@@ -139,7 +139,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator ReflectedGen: expression 'x => x.Property' targeted a valid member, but the type did not have a default constructor, so the member override would be ignored");
+                    .WithGenErrorMessage("expression 'x => x.Property' targeted a valid member, but the type did not have a default constructor, so the member override would be ignored");
             });
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutUnresolvableTypes.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutUnresolvableTypes.cs
@@ -18,7 +18,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
             action.Should()
                 .Throw<Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator ReflectedGen: could not resolve type 'System.Int32'");
+                .WithGenErrorMessage("could not resolve type 'System.Int32'");
         }
 
         private class ClassWithOneProperty
@@ -35,7 +35,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
             action.Should()
                 .Throw<Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator ReflectedGen: could not resolve type 'System.Int32' at path '$.Property'");
+                .WithGenErrorMessage("could not resolve type 'System.Int32' at path '$.Property'");
         }
 
         private class ClassWithOneNestedProperty
@@ -52,7 +52,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
             action.Should()
                 .Throw<Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator ReflectedGen: could not resolve type 'System.Int32' at path '$.Property.Property'");
+                .WithGenErrorMessage("could not resolve type 'System.Int32' at path '$.Property.Property'");
         }
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/ReflectedGenTests/AboutValidation.cs
@@ -19,7 +19,7 @@ namespace Tests.V2.GenTests.ReflectedGenTests
 
             test.Should()
                 .Throw<Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator ReflectedGen: type 'System.Int32' was not assignable to the type it was registered to, 'System.String'");
+                .WithGenErrorMessage("type 'System.Int32' was not assignable to the type it was registered to, 'System.String'");
         }
     }
 }

--- a/src/GalaxyCheck.Tests/GenTests/SetGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/SetGenTests/AboutValidation.cs
@@ -27,7 +27,7 @@ namespace Tests.V2.GenTests.SetGenTests
 
             test.Should()
                 .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator SetGen: 'count' cannot be negative");
+                .WithGenErrorMessage("'count' cannot be negative");
         }
 
         [Property]
@@ -43,7 +43,7 @@ namespace Tests.V2.GenTests.SetGenTests
 
             test.Should()
                 .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator SetGen: 'minCount' cannot be negative");
+                .WithGenErrorMessage("'minCount' cannot be negative");
         }
 
         [Property]
@@ -59,7 +59,7 @@ namespace Tests.V2.GenTests.SetGenTests
 
             test.Should()
                 .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                .WithMessage("Error while running generator SetGen: 'maxCount' cannot be negative");
+                .WithGenErrorMessage("'maxCount' cannot be negative");
         }
 
         [Property]
@@ -77,7 +77,7 @@ namespace Tests.V2.GenTests.SetGenTests
 
                     action.Should()
                         .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                        .WithMessage("Error while running generator SetGen: 'minCount' cannot be greater than 'maxCount'");
+                        .WithGenErrorMessage("'minCount' cannot be greater than 'maxCount'");
                 }
 
                 ShouldError(GalaxyCheck.Gen.Set(elementGen).WithCountGreaterThanEqual(minCount).WithCountLessThanEqual(maxCount));

--- a/src/GalaxyCheck.Tests/GenTests/StringGenTests/AboutValidation.cs
+++ b/src/GalaxyCheck.Tests/GenTests/StringGenTests/AboutValidation.cs
@@ -32,7 +32,7 @@ namespace Tests.V2.GenTests.StringGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator StringGen: 'charType' was not a valid flag value");
+                    .WithGenErrorMessage("'charType' was not a valid flag value");
             });
 
         [Property]
@@ -50,7 +50,7 @@ namespace Tests.V2.GenTests.StringGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator StringGen: 'chars' must not be empty");
+                    .WithGenErrorMessage("'chars' must not be empty");
             });
 
         [Property]
@@ -66,7 +66,7 @@ namespace Tests.V2.GenTests.StringGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator StringGen: 'length' cannot be negative");
+                    .WithGenErrorMessage("'length' cannot be negative");
             });
 
         [Property]
@@ -82,7 +82,7 @@ namespace Tests.V2.GenTests.StringGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator StringGen: 'minLength' cannot be negative");
+                    .WithGenErrorMessage("'minLength' cannot be negative");
             });
 
         [Property]
@@ -98,7 +98,7 @@ namespace Tests.V2.GenTests.StringGenTests
 
                 action.Should()
                     .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                    .WithMessage("Error while running generator StringGen: 'maxLength' cannot be negative");
+                    .WithGenErrorMessage("'maxLength' cannot be negative");
             });
 
         [Property]
@@ -115,7 +115,7 @@ namespace Tests.V2.GenTests.StringGenTests
 
                     action.Should()
                         .Throw<GalaxyCheck.Exceptions.GenErrorException>()
-                        .WithMessage("Error while running generator StringGen: 'minLength' cannot be greater than 'maxLength'");
+                        .WithGenErrorMessage("'minLength' cannot be greater than 'maxLength'");
                 }
 
                 ShouldError(GalaxyCheck.Gen.String().WithLengthGreaterThanEqual(minLength).WithLengthLessThanEqual(maxLength));

--- a/src/GalaxyCheck.Tests/RunnerTests/CheckTests/AboutReplay.cs
+++ b/src/GalaxyCheck.Tests/RunnerTests/CheckTests/AboutReplay.cs
@@ -55,7 +55,7 @@ namespace Tests.V2.RunnerTests.CheckTests
             from replayPath in Gen.Int32().ListOf()
             select Property.ForThese(() =>
             {
-                var property = GalaxyCheck.Gen.Advanced.Error<object>("", "").ForAll(func);
+                var property = GalaxyCheck.Gen.Advanced.Error<object>("").ForAll(func);
                 var replay = ReplayEncoding.Encode(CreateReplay(replaySeed, replaySize, replayPath));
 
                 Action test = () => property.Check(replay: replay);

--- a/src/GalaxyCheck/Gens/ByteGen.cs
+++ b/src/GalaxyCheck/Gens/ByteGen.cs
@@ -10,7 +10,7 @@
         /// generator size increases. However, byte generation can be customised using the builder methods on
         /// <see cref="IIntGen{byte}"/>.
         /// <returns>The new generator.</returns>
-        public static IIntGen<byte> Byte() => new ByteGen(nameof(Byte));
+        public static IIntGen<byte> Byte() => new ByteGen();
     }
 
     public static partial class Extensions
@@ -44,7 +44,7 @@
             }
             catch (OverflowException ex)
             {
-                return new FatalIntGen<byte>($"{nameof(Gen.Byte)}().{nameof(LessThan)}({maxExclusive})", ex);
+                return new FatalIntGen<byte>(ex);
             }
         }
 
@@ -64,7 +64,7 @@
             }
             catch (OverflowException ex)
             {
-                return new FatalIntGen<byte>($"{nameof(Gen.Byte)}().{nameof(GreaterThan)}({minExclusive})", ex);
+                return new FatalIntGen<byte>(ex);
             }
         }
     }
@@ -78,7 +78,6 @@ namespace GalaxyCheck.Gens
     using System.Collections.Generic;
 
     internal record ByteGen(
-        string PublicGenName,
         byte? Min = null,
         byte? Max = null,
         byte? Origin = null,
@@ -113,7 +112,7 @@ namespace GalaxyCheck.Gens
 
                 return gen
                     .Select(x => (byte)x)
-                    .SelectError(error => new GenErrorData(PublicGenName, error.Message));
+                    .SelectError(error => new GenErrorData(error.Message));
             }
         }
     }

--- a/src/GalaxyCheck/Gens/CharGen.cs
+++ b/src/GalaxyCheck/Gens/CharGen.cs
@@ -44,7 +44,7 @@ namespace GalaxyCheck.Gens
         {
             if (charType <= 0 || charType > Gen.CharType.All)
             {
-                return Gen.Advanced.Error<char>(nameof(CharGen), "'charType' was not a valid flag value");
+                return Gen.Advanced.Error<char>("'charType' was not a valid flag value");
             }
 
             var chars = CharacterSetsByFlag

--- a/src/GalaxyCheck/Gens/ChooseGen.cs
+++ b/src/GalaxyCheck/Gens/ChooseGen.cs
@@ -87,17 +87,17 @@ namespace GalaxyCheck.Gens
         {
             if (choices.Any() == false)
             {
-                return Gen.Advanced.Error<T>(nameof(ChooseGen<T>), "'choices' must be non-empty");
+                return Gen.Advanced.Error<T>("'choices' must be non-empty");
             }
 
             if (choices.Any(choice => choice.Weight < 0))
             {
-                return Gen.Advanced.Error<T>(nameof(ChooseGen<T>), "'choices' must not contain a negatively weighted generator");
+                return Gen.Advanced.Error<T>("'choices' must not contain a negatively weighted generator");
             }
 
             if (choices.Sum(choice => choice.Weight) == 0)
             {
-                return Gen.Advanced.Error<T>(nameof(ChooseGen<T>), "'choices' must contain at least one generator with a weight greater than zero");
+                return Gen.Advanced.Error<T>("'choices' must contain at least one generator with a weight greater than zero");
             }
 
             var weightedIndices = new WeightedList<int>(choices.Select((c, i) => new WeightedElement<int>(c.Weight, i)));

--- a/src/GalaxyCheck/Gens/DateTimeGen.cs
+++ b/src/GalaxyCheck/Gens/DateTimeGen.cs
@@ -158,7 +158,6 @@ namespace GalaxyCheck.Gens
                 .Select(seconds => TimeSpan.FromSeconds(seconds));
         }
 
-        private static IGen<DateTime> Error(string message) =>
-            Gen.Advanced.Error<DateTime>(nameof(DateTimeGen), message);
+        private static IGen<DateTime> Error(string message) => Gen.Advanced.Error<DateTime>(message);
     }
 }

--- a/src/GalaxyCheck/Gens/ElementGen.cs
+++ b/src/GalaxyCheck/Gens/ElementGen.cs
@@ -16,7 +16,7 @@ namespace GalaxyCheck
 
             if (sourceList.Count == 0)
             {
-                return Advanced.Error<T>(nameof(Element), "'source' must not be empty");
+                return Advanced.Error<T>("'source' must not be empty");
             }
 
             return Int32().Between(0, sourceList.Count - 1).Select(i => sourceList[i]);

--- a/src/GalaxyCheck/Gens/EnumGen.cs
+++ b/src/GalaxyCheck/Gens/EnumGen.cs
@@ -13,7 +13,7 @@
             var type = typeof(T);
             if (!type.IsEnum)
             {
-                return Advanced.Error<T>("EnumGen", $"Type '{type}' is not an enum");
+                return Advanced.Error<T>($"Type '{type}' is not an enum");
             }
 
             var isFlagsEnum = type.GetCustomAttributes<FlagsAttribute>().Any();

--- a/src/GalaxyCheck/Gens/ErrorGen.cs
+++ b/src/GalaxyCheck/Gens/ErrorGen.cs
@@ -10,23 +10,21 @@
             /// <summary>
             /// As an alternative to throwing exceptions, creates a generator that always errors. This is useful when
             /// writing custom generators - if any of the inputs were invalid, switching to an error generator ensures
-            /// that GalaxyCheck will handle the error through its normal error codepath. Otherwise, exceptions might
+            /// that GalaxyCheck will handle the error through its normal error code path. Otherwise, exceptions might
             /// bubble up and provide less-interesting diagnostics.
             /// </summary>
-            /// <param name="genName">The name of the generator where the error was detected.</param>
             /// <param name="message">A message explaining what this error is, and what it might have been caused by.
             /// </param>
             /// <returns>A new generator that errors when it runs.</returns>
-            public static IGen<T> Error<T>(string genName, string message) =>
-                new ErrorGen<T>(genName, message);
+            public static IGen<T> Error<T>(string message) => new ErrorGen<T>(message);
 
-            internal static IGen Error(Type type, string genName, string message)
+            internal static IGen Error(Type type, string message)
             {
                 var genericErrorGen = typeof(Advanced)
                     .GetMethod(nameof(Advanced.Error))!
                     .MakeGenericMethod(type);
 
-                return (IGen)genericErrorGen.Invoke(null, new object?[] { genName, message })!;
+                return (IGen)genericErrorGen.Invoke(null, new object?[] { message })!;
             }
         }
     }
@@ -42,12 +40,10 @@ namespace GalaxyCheck.Gens
 
     internal class ErrorGen<T> : BaseGen<T>, IGen<T>
     {
-        private readonly string _genName;
         private readonly string _message;
 
-        public ErrorGen(string genName, string message)
+        public ErrorGen(string message)
         {
-            _genName = genName;
             _message = message;
         }
 
@@ -55,7 +51,7 @@ namespace GalaxyCheck.Gens
         {
             while (true)
             {
-                yield return GenIterationFactory.Error<T>(parameters, parameters, _genName, _message);
+                yield return GenIterationFactory.Error<T>(parameters, parameters, _message);
             }
         }
     }

--- a/src/GalaxyCheck/Gens/FactoryGen.cs
+++ b/src/GalaxyCheck/Gens/FactoryGen.cs
@@ -230,6 +230,6 @@ namespace GalaxyCheck.Gens
                 _ => throw new NotSupportedException($"Type not supported in switch: {overrideMemberError.GetType()}")
             };
 
-        private static IGen<T> Error(string message) => Gen.Advanced.Error<T>(nameof(ReflectedGen<T>), message);
+        private static IGen<T> Error(string message) => Gen.Advanced.Error<T>(message);
     }
 }

--- a/src/GalaxyCheck/Gens/IIntGen.cs
+++ b/src/GalaxyCheck/Gens/IIntGen.cs
@@ -37,12 +37,10 @@ namespace GalaxyCheck.Gens
 
     internal record FatalIntGen<T> : GenProvider<T>, IIntGen<T>
     {
-        private readonly string _publicGenName;
         private readonly Exception _ex;
 
-        public FatalIntGen(string publicGenName, Exception ex)
+        public FatalIntGen(Exception ex)
         {
-            _publicGenName = publicGenName;
             _ex = ex;
         }
 
@@ -54,6 +52,6 @@ namespace GalaxyCheck.Gens
 
         public IIntGen<T> WithBias(Gen.Bias bias) => this;
 
-        protected override IGen<T> Get => Gen.Advanced.Error<T>(_publicGenName, _ex.Message);
+        protected override IGen<T> Get => Gen.Advanced.Error<T>(_ex.Message);
     }
 }

--- a/src/GalaxyCheck/Gens/Int16Gen.cs
+++ b/src/GalaxyCheck/Gens/Int16Gen.cs
@@ -10,7 +10,7 @@
         /// <see cref="short.MinValue"/> and <see cref="short.MaxValue"/>, as the generator size increases. However,
         /// short generation can be customised using the builder methods on <see cref="IIntGen{short}"/>.
         /// <returns>The new generator.</returns>
-        public static IIntGen<short> Int16() => new Int16Gen(nameof(Int16));
+        public static IIntGen<short> Int16() => new Int16Gen();
     }
 
     public static partial class Extensions
@@ -44,7 +44,7 @@
             }
             catch (OverflowException ex)
             {
-                return new FatalIntGen<short>($"{nameof(Gen.Int16)}().{nameof(LessThan)}({maxExclusive})", ex);
+                return new FatalIntGen<short>(ex);
             }
         }
 
@@ -64,7 +64,7 @@
             }
             catch (OverflowException ex)
             {
-                return new FatalIntGen<short>($"{nameof(Gen.Int16)}().{nameof(GreaterThan)}({minExclusive})", ex);
+                return new FatalIntGen<short>(ex);
             }
         }
     }
@@ -76,7 +76,6 @@ namespace GalaxyCheck.Gens
     using GalaxyCheck.Gens.Iterations.Generic;
 
     internal record Int16Gen(
-        string PublicGenName,
         short? Min = null,
         short? Max = null,
         short? Origin = null,
@@ -111,7 +110,7 @@ namespace GalaxyCheck.Gens
 
                 return gen
                     .Select(x => (short)x)
-                    .SelectError(error => new GenErrorData(PublicGenName, error.Message));
+                    .SelectError(error => new GenErrorData(error.Message));
             }
         }
     }

--- a/src/GalaxyCheck/Gens/Int32Gen.cs
+++ b/src/GalaxyCheck/Gens/Int32Gen.cs
@@ -10,7 +10,7 @@
         /// <see cref="int.MinValue"/> and <see cref="int.MaxValue"/>, as the generator size increases. However,
         /// int generation can be customised using the builder methods on <see cref="IIntGen{int}"/>.
         /// <returns>The new generator.</returns>
-        public static IIntGen<int> Int32() => new Int32Gen(nameof(Int32));
+        public static IIntGen<int> Int32() => new Int32Gen();
     }
 
     public static partial class Extensions
@@ -44,7 +44,7 @@
             }
             catch (OverflowException ex)
             {
-                return new FatalIntGen<int>($"{nameof(Gen.Int32)}().{nameof(LessThan)}({maxExclusive})", ex);
+                return new FatalIntGen<int>(ex);
             }
         }
 
@@ -64,7 +64,7 @@
             }
             catch (OverflowException ex)
             {
-                return new FatalIntGen<int>($"{nameof(Gen.Int32)}().{nameof(GreaterThan)}({minExclusive})", ex);
+                return new FatalIntGen<int>(ex);
             }
         }
     }
@@ -76,7 +76,6 @@ namespace GalaxyCheck.Gens
     using GalaxyCheck.Gens.Iterations.Generic;
 
     internal record Int32Gen(
-        string PublicGenName,
         int? Min = null,
         int? Max = null,
         int? Origin = null,
@@ -111,7 +110,7 @@ namespace GalaxyCheck.Gens
 
                 return gen
                     .Select(x => (int)x)
-                    .SelectError(error => new GenErrorData(PublicGenName, error.Message));
+                    .SelectError(error => new GenErrorData(error.Message));
             }
         }
     }

--- a/src/GalaxyCheck/Gens/Int64Gen.cs
+++ b/src/GalaxyCheck/Gens/Int64Gen.cs
@@ -11,7 +11,7 @@
         /// configuration methods to constrain the produced integers further.
         /// </summary>
         /// <returns>The new generator.</returns>
-        public static IIntGen<long> Int64() => new Int64Gen(nameof(Int64));
+        public static IIntGen<long> Int64() => new Int64Gen();
     }
 
     public static partial class Extensions
@@ -45,7 +45,7 @@
             }
             catch (OverflowException ex)
             {
-                return new FatalIntGen<long>($"{nameof(Gen.Int64)}().{nameof(LessThan)}({maxExclusive})", ex);
+                return new FatalIntGen<long>(ex);
             }
         }
 
@@ -65,7 +65,7 @@
             }
             catch (OverflowException ex)
             {
-                return new FatalIntGen<long>($"{nameof(Gen.Int64)}().{nameof(GreaterThan)}({minExclusive})", ex);
+                return new FatalIntGen<long>(ex);
             }
         }
     }
@@ -80,7 +80,6 @@ namespace GalaxyCheck.Gens
     using System;
 
     internal record Int64Gen(
-        string PublicGenName,
         long? Min = null,
         long? Max = null,
         long? Origin = null,
@@ -103,12 +102,12 @@ namespace GalaxyCheck.Gens
 
                 if (min > max)
                 {
-                    return Error(PublicGenName, "'min' cannot be greater than 'max'");
+                    return Error("'min' cannot be greater than 'max'");
                 }
 
                 if (Origin != null && (Origin < min || Origin > max))
                 {
-                    return Error(PublicGenName, "'origin' must be between 'min' and 'max'");
+                    return Error("'origin' must be between 'min' and 'max'");
                 }
 
                 if (min == max)
@@ -222,7 +221,7 @@ namespace GalaxyCheck.Gens
             ExtremeMaximum = 2
         }
 
-        private static IGen<long> Error(string publicGenName, string message) => Gen.Advanced.Error<long>(publicGenName, message);
+        private static IGen<long> Error(string message) => Gen.Advanced.Error<long>(message);
 
         /// <summary>
         /// Infer the origin by finding the closest value to 0 that is within the bounds.

--- a/src/GalaxyCheck/Gens/Internal/Iterations/GenIterationExtensions.cs
+++ b/src/GalaxyCheck/Gens/Internal/Iterations/GenIterationExtensions.cs
@@ -9,7 +9,7 @@ namespace GalaxyCheck.Gens.Internal.Iterations
             this IGenIteration<TSource> iteration) => iteration.Match<Either<IGenInstance<TSource>, IGenIteration<TNonInstance>>>(
                 onInstance: instance => new Left<IGenInstance<TSource>, IGenIteration<TNonInstance>>(instance),
                 onError: error => new Right<IGenInstance<TSource>, IGenIteration<TNonInstance>>(
-                    GenIterationFactory.Error<TNonInstance>(error.ReplayParameters, error.NextParameters, error.GenName, error.Message)),
+                    GenIterationFactory.Error<TNonInstance>(error.ReplayParameters, error.NextParameters, error.Message)),
                 onDiscard: discard => new Right<IGenInstance<TSource>, IGenIteration<TNonInstance>>(
                     GenIterationFactory.Discard<TNonInstance>(discard.ReplayParameters, discard.NextParameters, discard.ExampleSpace)));
 

--- a/src/GalaxyCheck/Gens/Internal/Iterations/GenIterationFactory.cs
+++ b/src/GalaxyCheck/Gens/Internal/Iterations/GenIterationFactory.cs
@@ -3,8 +3,6 @@ using GalaxyCheck.Gens.Iterations.Generic;
 using GalaxyCheck.Gens.Parameters;
 using GalaxyCheck.ExampleSpaces;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace GalaxyCheck.Gens.Internal.Iterations
 {
@@ -30,7 +28,7 @@ namespace GalaxyCheck.Gens.Internal.Iterations
 
             IGenData IGenIteration.Data => Data.Match<IGenData>(
                 onInstance: instanceData => GenData.InstanceData(instanceData.ExampleSpace),
-                onError: errorData => GenData.ErrorData(errorData.GenName, errorData.Message),
+                onError: errorData => GenData.ErrorData(errorData.Message),
                 onDiscard: discardData => GenData.DiscardData(discardData.ExampleSpace));
 
             public TResult Match<TResult>(
@@ -66,8 +64,6 @@ namespace GalaxyCheck.Gens.Internal.Iterations
                 {
                 }
 
-                public string GenName => Data.Error!.GenName;
-
                 public string Message => Data.Error!.Message;
             }
 
@@ -97,11 +93,10 @@ namespace GalaxyCheck.Gens.Internal.Iterations
         public static IGenIteration<T> Error<T>(
             GenParameters replayParameters,
             GenParameters nextParameters,
-            string genName,
             string message) => new GenIteration<T>(
                 replayParameters,
                 nextParameters,
-                GenData<T>.ErrorData(genName, message));
+                GenData<T>.ErrorData(message));
 
         public static IGenIteration<T> Discard<T>(
             GenParameters replayParameters,

--- a/src/GalaxyCheck/Gens/Iterations/GenIteration.cs
+++ b/src/GalaxyCheck/Gens/Iterations/GenIteration.cs
@@ -35,8 +35,6 @@ namespace GalaxyCheck.Gens.Iterations
 
     public interface IGenErrorData
     {
-        string GenName { get; }
-
         string Message { get; }
     }
 
@@ -47,7 +45,7 @@ namespace GalaxyCheck.Gens.Iterations
 
     public record GenInstanceData(IExampleSpace ExampleSpace) : IGenInstanceData;
 
-    public record GenErrorData(string GenName, string Message) : IGenErrorData;
+    public record GenErrorData(string Message) : IGenErrorData;
 
     public record GenDiscardData(IExampleSpace ExampleSpace) : IGenDiscardData;
 
@@ -60,10 +58,10 @@ namespace GalaxyCheck.Gens.Iterations
             Discard = null
         };
 
-        public static GenData ErrorData(string genName, string message) => new GenData
+        public static GenData ErrorData(string message) => new GenData
         {
             Instance = null,
-            Error = new GenErrorData(genName, message),
+            Error = new GenErrorData(message),
             Discard = null
         };
 

--- a/src/GalaxyCheck/Gens/Iterations/Generic/GenIteration.cs
+++ b/src/GalaxyCheck/Gens/Iterations/Generic/GenIteration.cs
@@ -50,7 +50,7 @@ namespace GalaxyCheck.Gens.Iterations.Generic
         IExampleSpace IGenInstanceData.ExampleSpace => ExampleSpace;
     }
 
-    public record GenErrorData(string GenName, string Message) : IGenErrorData;
+    public record GenErrorData(string Message) : IGenErrorData;
 
     public record GenDiscardData(IExampleSpace ExampleSpace) : IGenDiscardData;
 
@@ -63,10 +63,10 @@ namespace GalaxyCheck.Gens.Iterations.Generic
             Discard = null
         };
 
-        public static GenData<T> ErrorData(string genName, string message) => new GenData<T>
+        public static GenData<T> ErrorData(string message) => new GenData<T>
         {
             Instance = null,
-            Error = new GenErrorData(genName, message),
+            Error = new GenErrorData(message),
             Discard = null
         };
 

--- a/src/GalaxyCheck/Gens/ListGen.cs
+++ b/src/GalaxyCheck/Gens/ListGen.cs
@@ -305,7 +305,7 @@ namespace GalaxyCheck.Gens
             }
         }
 
-        private static IGen<IReadOnlyList<T>> Error(string message) => Gen.Advanced.Error<IReadOnlyList<T>>(nameof(ListGen<T>), message);
+        private static IGen<IReadOnlyList<T>> Error(string message) => Gen.Advanced.Error<IReadOnlyList<T>>(message);
 
         private static IGen<IReadOnlyList<T>> CountLimitError() =>
             Error($"Count limit exceeded. This is a built-in safety mechanism to prevent hanging tests. If generating a list with over 1000 elements was intended, relax this constraint by calling {nameof(IListGen<T>)}.{nameof(IListGen<T>.DisableCountLimitUnsafe)}().");

--- a/src/GalaxyCheck/Gens/ParametersGen.cs
+++ b/src/GalaxyCheck/Gens/ParametersGen.cs
@@ -59,12 +59,10 @@ namespace GalaxyCheck.Gens
         {
             var parameters = methodInfo.GetParameters();
 
-            var invalidIndicies = customGens.Keys.Except(Enumerable.Range(0, parameters.Length));
-            if (invalidIndicies.Any())
+            var invalidIndex = customGens.Keys.Except(Enumerable.Range(0, parameters.Length)).Cast<int?>().FirstOrDefault();
+            if (invalidIndex is not null)
             {
-                return Gen.Advanced.Error<object[]>(
-                    nameof(ParametersGen),
-                    $"parameter index '{invalidIndicies.First()}' of custom generator was not valid");
+                return Gen.Advanced.Error<object[]>($"parameter index '{invalidIndex.Value}' of custom generator was not valid");
             }
 
             var gens = parameters
@@ -103,7 +101,6 @@ namespace GalaxyCheck.Gens
                 if (parameterInfo.ParameterType.IsAssignableFrom(genTypeArgument) == false)
                 {
                     return Gen.Advanced.Error<object>(
-                        nameof(ParametersGen),
                         $"generator of type '{genTypeArgument.FullName}' is not compatible with parameter of type '{parameterInfo.ParameterType.FullName}'");
                 }
 
@@ -139,7 +136,6 @@ namespace GalaxyCheck.Gens
             {
                 gen = Gen.Advanced.Error(
                     parameterInfo.ParameterType,
-                    nameof(ParametersGen),
                     $"multiple {nameof(GenAttribute)}s is unsupported");
                 return true;
             }
@@ -150,9 +146,7 @@ namespace GalaxyCheck.Gens
 
         private static Iterations.IGenErrorData SelectParameterError(ParameterInfo parameterInfo, Iterations.IGenErrorData error)
         {
-            return new GenErrorData(
-                nameof(ParametersGen),
-                $"unable to generate value for parameter '{parameterInfo.Name}', {error.Message}");
+            return new GenErrorData($"unable to generate value for parameter '{parameterInfo.Name}', {error.Message}");
         }
     }
 }

--- a/src/GalaxyCheck/Gens/SetGen.cs
+++ b/src/GalaxyCheck/Gens/SetGen.cs
@@ -323,7 +323,6 @@ namespace GalaxyCheck.Gens
                 onBounded: (minCount, maxCount) => FromBounded(minCount, maxCount));
         }
 
-        private static IGen<IReadOnlySet<T>> Error(string message) =>
-            Gen.Advanced.Error<IReadOnlySet<T>>(nameof(SetGen<T>), message);
+        private static IGen<IReadOnlySet<T>> Error(string message) => Gen.Advanced.Error<IReadOnlySet<T>>(message);
     }
 }

--- a/src/GalaxyCheck/Gens/StringGen.cs
+++ b/src/GalaxyCheck/Gens/StringGen.cs
@@ -196,7 +196,7 @@ namespace GalaxyCheck.Gens
 
         private static IGen<char> CreateCharGen(StringGenCharConfig? charConfig)
         {
-            static IGen<char> Error(string message) => Gen.Advanced.Error<char>(nameof(StringGen), message);
+            static IGen<char> Error(string message) => Gen.Advanced.Error<char>(message);
 
             charConfig ??= new StringGenCharConfig.FromCharType(Gen.CharType.All);
 
@@ -230,7 +230,7 @@ namespace GalaxyCheck.Gens
         private static IGen<IReadOnlyList<char>> CreateListGen(IGen<char> charGen, StringGenLengthConfig? lengthConfig, Gen.Bias? lengthBias)
         {
             static IGen<IReadOnlyList<char>> Error(string message) =>
-                Gen.Advanced.Error<IReadOnlyList<char>>(nameof(StringGen), message);
+                Gen.Advanced.Error<IReadOnlyList<char>>(message);
 
             lengthConfig ??= new StringGenLengthConfig.Ranged(null, null);
 

--- a/src/GalaxyCheck/Operators/Cast.cs
+++ b/src/GalaxyCheck/Operators/Cast.cs
@@ -18,7 +18,6 @@ namespace GalaxyCheck
                     onError: error => GenIterationFactory.Error<T>(
                         iteration.ReplayParameters,
                         iteration.NextParameters,
-                        error.GenName,
                         error.Message),
                     onDiscard: discard => GenIterationFactory.Discard<T>(
                         iteration.ReplayParameters,

--- a/src/GalaxyCheck/Operators/SelectError.cs
+++ b/src/GalaxyCheck/Operators/SelectError.cs
@@ -16,7 +16,6 @@ namespace GalaxyCheck
                 return GenIterationFactory.Error<T>(
                     error.ReplayParameters,
                     error.NextParameters,
-                    selectedErrorData.GenName,
                     selectedErrorData.Message);
             }
 

--- a/src/GalaxyCheck/Operators/SelectMany.cs
+++ b/src/GalaxyCheck/Operators/SelectMany.cs
@@ -115,7 +115,6 @@ namespace GalaxyCheck
                                 onError: innerError => GenIterationFactory.Error<TResult>(
                                     iteration.ReplayParameters,
                                     innerIteration.NextParameters,
-                                    innerError.GenName,
                                     innerError.Message),
                                 onDiscard: innerDiscard => GenIterationFactory.Discard<TResult>(
                                     iteration.ReplayParameters,

--- a/src/GalaxyCheck/Runners/Check/AsyncAutomata/GenerationStates.cs
+++ b/src/GalaxyCheck/Runners/Check/AsyncAutomata/GenerationStates.cs
@@ -42,7 +42,7 @@ namespace GalaxyCheck.Runners.Check.AsyncAutomata
                     onDiscard: (discard) =>
                         new Generation_Discard<T>(tail, discard),
                     onError: (error) =>
-                        new Generation_Error<T>($"Error while running generator {error.GenName}: {error.Message}"));
+                        new Generation_Error<T>($"Error during generation: {error.Message}"));
 
                 return Task.FromResult(new CheckStateTransition<T>(state, context));
             }

--- a/src/GalaxyCheck/Runners/Check/Automata/GenerationStates.cs
+++ b/src/GalaxyCheck/Runners/Check/Automata/GenerationStates.cs
@@ -39,7 +39,7 @@ namespace GalaxyCheck.Runners.Check.Automata
                     onDiscard: (discard) =>
                         new Generation_Discard<T>(tail, discard),
                     onError: (error) =>
-                        new Generation_Error<T>($"Error while running generator {error.GenName}: {error.Message}"));
+                        new Generation_Error<T>($"Error during generation: {error.Message}"));
 
                 return new CheckStateTransition<T>(state, context);
             }


### PR DESCRIPTION
No need to show a (probably) internal generator name. It's confusing and it complects more useful diagnostics.
