### PR TITLE
🌍 #371 Fix infinite rendering loop on static properties

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ indent_size = 4
 indent_size = 4
 insert_final_newline = true
 charset = utf-8-bom
+max_line_length = 150
 
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
@@ -84,9 +85,9 @@ dotnet_naming_symbols.public_internal_fields.applicable_accessibilities = public
 dotnet_naming_symbols.public_internal_fields.applicable_kinds = field
 # private_protected_fields - Define private and protected fields
 dotnet_naming_symbols.private_protected_fields.applicable_accessibilities = private, protected
-dotnet_naming_symbols.private_protected_fields.applicable_kinds = field 
+dotnet_naming_symbols.private_protected_fields.applicable_kinds = field
 # private_fields - Define private fields
-dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_kinds = field
 dotnet_naming_symbols.private_fields.applicable_accessibilities = private
 # public_symbols - Define any public symbol
 dotnet_naming_symbols.public_symbols.applicable_accessibilities = public, internal, protected, protected_internal
@@ -107,7 +108,7 @@ dotnet_naming_style.pascal_case.capitalization = pascal_case
 dotnet_naming_style.first_upper.capitalization = first_word_upper
 # prefix_interface_interface_with_i - Interfaces must be PascalCase and the first character of an interface must be an 'I'
 dotnet_naming_style.prefix_interface_interface_with_i.required_prefix = I
-dotnet_naming_style.prefix_interface_interface_with_i.capitalization = pascal_case 
+dotnet_naming_style.prefix_interface_interface_with_i.capitalization = pascal_case
 # prefix_underscore - Define the prefix underscore style
 dotnet_naming_style.prefix_underscore.capitalization = camel_case
 dotnet_naming_style.prefix_underscore.required_prefix = _
@@ -124,7 +125,7 @@ dotnet_naming_rule.non_private_readonly_fields_must_be_pascal_case.style = pasca
 # Static readonly fields must be PascalCase
 dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.severity = warning
 dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.symbols = static_readonly_fields
-dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.style = pascal_case 
+dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.style = pascal_case
 # Private readonly fields be prefixed with underscore
 dotnet_naming_rule.private_readonly_fields_with_underscore.severity = warning
 dotnet_naming_rule.private_readonly_fields_with_underscore.symbols = private_readonly_fields
@@ -132,7 +133,7 @@ dotnet_naming_rule.private_readonly_fields_with_underscore.style = prefix_unders
 # Private fields must be prefixed with underscore
 dotnet_naming_rule.private_members_with_underscore.severity = warning
 dotnet_naming_rule.private_members_with_underscore.symbols = private_fields
-dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
+dotnet_naming_rule.private_members_with_underscore.style = prefix_underscore
 # Public and internal fields must be PascalCase
 dotnet_naming_rule.public_internal_fields_must_be_pascal_case.severity = warning
 dotnet_naming_rule.public_internal_fields_must_be_pascal_case.symbols = public_internal_fields
@@ -161,7 +162,7 @@ dotnet_naming_rule.interface_types_must_be_prefixed_with_i.style = prefix_interf
 # C# Code Style Settings
 # See https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
 # See http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers
-[*.cs,csx,cake]
+[*.cs,csx, cake]
 # Indentation Options
 csharp_indent_block_contents = true:warning
 csharp_indent_braces = false:warning

--- a/GalaxyCheck.sln
+++ b/GalaxyCheck.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GalaxyCheck.Xunit.CodeAnaly
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GalaxyCheck.Xunit.CodeAnalysis.Tests", "src\GalaxyCheck.Xunit.CodeAnalysis.Tests\GalaxyCheck.Xunit.CodeAnalysis.Tests.csproj", "{0BBFED38-BA46-451A-B346-67F29CFCDA04}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GalaxyCheck.Tests.V3", "src\GalaxyCheck.Tests.V3\GalaxyCheck.Tests.V3.csproj", "{0C715CD7-6439-49FB-BB80-3D80D24AFE9F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +65,10 @@ Global
 		{0BBFED38-BA46-451A-B346-67F29CFCDA04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0BBFED38-BA46-451A-B346-67F29CFCDA04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0BBFED38-BA46-451A-B346-67F29CFCDA04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C715CD7-6439-49FB-BB80-3D80D24AFE9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C715CD7-6439-49FB-BB80-3D80D24AFE9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C715CD7-6439-49FB-BB80-3D80D24AFE9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C715CD7-6439-49FB-BB80-3D80D24AFE9F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/GalaxyCheck.Tests.V3/FeatureInteractions/readme.md
+++ b/src/GalaxyCheck.Tests.V3/FeatureInteractions/readme.md
@@ -1,0 +1,6 @@
+# Feature Interactions
+
+This is a collection of tests about interesting interactions between mostly-isolated features. Especially compositions
+that result in hairy interactions, or compositions that are not intuitive and need to be documented.
+
+Features are tested in isolation elsewhere.

--- a/src/GalaxyCheck.Tests.V3/Features/Properties/AboutFailingTests.cs
+++ b/src/GalaxyCheck.Tests.V3/Features/Properties/AboutFailingTests.cs
@@ -1,0 +1,20 @@
+﻿using GalaxyCheck;
+
+namespace GalaxyCheck_Tests_V3.Features.Properties;
+
+public class AboutFailingTests
+{
+    [Fact]
+    public void ItShouldFail()
+    {
+        // Arrange
+        var property = Gen.Constant(true).ForAll(x => x == false);
+
+        // Act
+        var result = property.Check();
+
+        // Assert
+        result.Falsified.Should().BeTrue();
+        result.Iterations.Should().Be(1);
+    }
+}

--- a/src/GalaxyCheck.Tests.V3/GalaxyCheck.Tests.V3.csproj
+++ b/src/GalaxyCheck.Tests.V3/GalaxyCheck.Tests.V3.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+
+    <RootNamespace>GalaxyCheck_Tests_V3</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.11.0"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+    <PackageReference Include="NebulaCheck.Xunit" Version="0.0.0-4021874656"/>
+    <PackageReference Include="xunit" Version="2.4.2"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GalaxyCheck.Xunit\GalaxyCheck.Xunit.csproj"/>
+    <ProjectReference Include="..\GalaxyCheck\GalaxyCheck.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/src/GalaxyCheck.Tests.V3/TestProxy.cs
+++ b/src/GalaxyCheck.Tests.V3/TestProxy.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+using GalaxyCheck;
+using GalaxyCheck.Runners.Check;
+
+namespace GalaxyCheck_Tests_V3;
+
+public static class TestProxy
+{
+    public static CheckResult<T> Check<T>(this Property<T> property, Func<CheckPropertyArgs, CheckPropertyArgs>? configure = null)
+    {
+        var args = CheckPropertyArgs.Default;
+        if (configure != null)
+        {
+            args = configure(args);
+        }
+
+        // Rider can't handle static partial extensions :( Completely shits itself.
+        var result = typeof(Extensions)
+            .GetMethod(nameof(Check))!
+            .MakeGenericMethod(typeof(T))
+            .Invoke(null, new object?[] { property, null, args.Seed, null, null, null, true })!;
+        return (CheckResult<T>)result;
+    }
+
+    public record CheckPropertyArgs(int Seed)
+    {
+        public static CheckPropertyArgs Default { get; } = new(0);
+    }
+}

--- a/src/GalaxyCheck.Tests.V3/Usings.cs
+++ b/src/GalaxyCheck.Tests.V3/Usings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using FluentAssertions;

--- a/src/GalaxyCheck.Tests/RendererTests/AboutUnaryExamples.cs
+++ b/src/GalaxyCheck.Tests/RendererTests/AboutUnaryExamples.cs
@@ -46,7 +46,7 @@ namespace Tests.V2.RendererTests
         {
             { new Tuple<int, int, int>(1, 2, 3), new object[] { 1, 2, 3 } },
             { (1, 2, 3), new object[] { 1, 2, 3 } },
-            { (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), new object[] {1, 2, 3, 4, 5, 6, 7 } },
+            { (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), new object[] { 1, 2, 3, 4, 5, 6, 7 } },
         };
 
         [Theory]
@@ -87,8 +87,21 @@ namespace Tests.V2.RendererTests
             { new Dictionary<RecordObj, int> { { new RecordObj(1, 2, 3), 4 } }, "[{ Key = { A = 1, B = 2, C = 3 }, Value = 4 }]" },
             { new RecordObj(1, 2, 3), "{ A = 1, B = 2, C = 3 }" },
             { new RecordObjWithList(new List<int> { 1, 2, 3 }), "{ As = [1, 2, 3] }" },
-            { new RecordObjWithManyProperties(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), "{ A = 1, B = 2, C = 3, D = 4, E = 5, F = 6, G = 7, H = 8, I = 9, J = 10, ... }" },
-            { new { a = new { b = new { c = new { d = new { e = new { f = new { g = new { h = new { i = new { j = new { k = new { } } } } } } } } } } } }, "{ a = { b = { c = { d = { e = { f = { g = { h = { i = { j = ... } } } } } } } } } }" },
+            {
+                new RecordObjWithManyProperties(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+                "{ A = 1, B = 2, C = 3, D = 4, E = 5, F = 6, G = 7, H = 8, I = 9, J = 10, ... }"
+            },
+            { new RecordWithStaticProperty(1), "{ A = 1 }" },
+            {
+                new
+                {
+                    a = new
+                    {
+                        b = new { c = new { d = new { e = new { f = new { g = new { h = new { i = new { j = new { k = new { } } } } } } } } } }
+                    }
+                },
+                "{ a = { b = { c = { d = { e = { f = { g = { h = { i = { j = ... } } } } } } } } } }"
+            },
             { new ClassObj(1, 2, 3), "{ A = 1, B = 2, C = 3 }" },
             { new { a = 1, b = 2, c = 3 }, "{ a = 1, b = 2, c = 3 }" },
             { new Func<int, bool>((_) => true), "System.Func`2[System.Int32,System.Boolean]" },
@@ -147,10 +160,15 @@ namespace Tests.V2.RendererTests
         public struct Struct
         {
             public int A { get; set; }
-            
+
             public int B { get; set; }
-            
+
             public int C { get; set; }
+        }
+
+        public record RecordWithStaticProperty(int A)
+        {
+            public static int B => 2;
         }
     }
 }

--- a/src/GalaxyCheck/Runners/Check.cs
+++ b/src/GalaxyCheck/Runners/Check.cs
@@ -15,13 +15,13 @@ namespace GalaxyCheck
     public static partial class Extensions
     {
         public static CheckResult<T> Check<T>(
-             this IGen<Property.Test<T>> property,
-             int? iterations = null,
-             int? seed = null,
-             int? size = null,
-             int? shrinkLimit = null,
-             string? replay = null,
-             bool deepCheck = true)
+            this IGen<Property.Test<T>> property,
+            int? iterations = null,
+            int? seed = null,
+            int? size = null,
+            int? shrinkLimit = null,
+            string? replay = null,
+            bool deepCheck = true)
         {
             var resolvedIterations = iterations ?? 100;
             var (initialSize, resizeStrategy) = SizingAspects<T>.Resolve(size == null ? null : new Size(size.Value), resolvedIterations);
@@ -60,13 +60,13 @@ namespace GalaxyCheck
         }
 
         public static async Task<CheckResult<T>> CheckAsync<T>(
-             this IGen<Property.AsyncTest<T>> property,
-             int? iterations = null,
-             int? seed = null,
-             int? size = null,
-             int? shrinkLimit = null,
-             string? replay = null,
-             bool deepCheck = true)
+            this IGen<Property.AsyncTest<T>> property,
+            int? iterations = null,
+            int? seed = null,
+            int? size = null,
+            int? shrinkLimit = null,
+            string? replay = null,
+            bool deepCheck = true)
         {
             var resolvedIterations = iterations ?? 100;
             var (initialSize, resizeStrategy) = SizingAspectsAsync<T>.Resolve(size == null ? null : new Size(size.Value), resolvedIterations);


### PR DESCRIPTION
It's not meaningful to render static properties on a (non-static) counterexample, so don't.

Also, this was causing an infinite loop when rendering a counterexample containing System.Drawing.Color. I've put in an extra safeguard, so that the object renderer checks that it isn't rendering a type that it hasn't just seen.
